### PR TITLE
Web of Science API key setting support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.idea/
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,4 @@
 
 tokens:
   cap: 'dummyvalue'
+  wos: 'evendumbervalue'


### PR DESCRIPTION
Adds WOS key to settings and ignore .idea files.