### PR TITLE
Pin oauth2 gem to a version that works.

### DIFF
--- a/rialto-etl.gemspec
+++ b/rialto-etl.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'httpclient'
   spec.add_dependency 'json-ld'
-  spec.add_dependency 'oauth2'
+  spec.add_dependency 'oauth2', '~> 1.4'
   spec.add_dependency 'rdf'
   spec.add_dependency 'ruby-progressbar'
   spec.add_dependency 'sparql-client', '~> 3.0'


### PR DESCRIPTION
For some reason the latest version of the oauth2 gem doesn't seem to let me actually do anything. Pinning the version seems to fix the problem.