### PR TITLE
Allow any API key when testing

### DIFF
--- a/spec/service_client/web_of_science_client_spec.rb
+++ b/spec/service_client/web_of_science_client_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Rialto::Etl::ServiceClient::WebOfScienceClient do
       stub_request(:get, 'https://api.clarivate.com/api/wos?count=100&databaseId=WOS&firstRecord=1&usrQuery=AU=Altman,Russ%20AND%20OG=Stanford%20University')
         .with(
           headers: {
-            'X-Apikey' => 'evendumbervalue'
+            'X-Apikey' => /.*/
           }
         )
         .to_return(status: 200, body: 'Dood', headers: {})


### PR DESCRIPTION
If you have an existing config/settings.local.yml with your local values for API keys, URLs etc. then that local settings file will be loaded and you might end up with a different 'X-Apikey' value in the GET request (if you have an actual API key other than 'evendumbervalue').

This PR allows any value at all for the API key.