### PR TITLE
Remove default setting for the :institution command-line option

### DIFF
--- a/lib/rialto/etl/cli/extract.rb
+++ b/lib/rialto/etl/cli/extract.rb
@@ -21,7 +21,6 @@ module Rialto
 
         option :institution,
                required: false,
-               default: 'Stanford University',
                banner: 'INSTITUTION',
                desc: 'Institution name (for WebOfScience)',
                aliases: '-i'


### PR DESCRIPTION
Thor options that are marked `default` will always be part of the `options` hash here:

https://github.com/sul-dlss-labs/rialto-etl/blob/master/lib/rialto/etl/cli/extract.rb#L53

This causes the command `exe/extract call StanfordResearchers` to fail, since this argument is not accounted for here: https://github.com/sul-dlss-labs/rialto-etl/blob/master/lib/rialto/etl/extractors/stanford_researchers.rb#L10

I suppose a different approach would be to modify https://github.com/sul-dlss-labs/rialto-etl/blob/master/lib/rialto/etl/extractors/stanford_researchers.rb instead - I'm completely open to that.