### PR TITLE
Update Faraday to 0.15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,14 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in rialto-etl.gemspec
 gemspec
 
+# Bundler uses the insecure git protocol by default which causes a warning.
+# Switch to HTTPS instead:
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+# The released version of oauth2 is very old and won't support Faraday 0.15,
+# which we need in order to use net-http-persistent 3.0
+gem 'oauth2', github: 'oauth-xx/oauth2'
+
 group :development, :test do
   gem 'pry' unless ENV['CI']
   gem 'pry-byebug' unless ENV['CI']

--- a/rialto-etl.gemspec
+++ b/rialto-etl.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '~> 5.2'
   spec.add_dependency 'config'
-  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday', '~> 0.15.0'
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'httpclient'
   spec.add_dependency 'json-ld'


### PR DESCRIPTION
This is required in order to support net-http-persistent 3.0.0
Fixes #115