### PR TITLE
Use params-based auth in favor of basic auth

### DIFF
--- a/lib/rialto/etl/extractors/sera.rb
+++ b/lib/rialto/etl/extractors/sera.rb
@@ -33,7 +33,8 @@ module Rialto
         def token
           client = OAuth2::Client.new(::Settings.tokens.sera.clientid,
                                       ::Settings.tokens.sera.secret,
-                                      token_url: ::Settings.sera.token_url)
+                                      token_url: ::Settings.sera.token_url,
+                                      auth_scheme: :request_body)
           client.client_credentials.get_token.token
         end
 


### PR DESCRIPTION
Fixes sul-dlss-labs/rialto-etl#123