### PR TITLE
Guard against people with no positions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,10 @@ RSpec/DescribeClass:
   Exclude:
     - spec/transform/*.rb
 
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
 RSpec/NestedGroups:
   Max: 4
 

--- a/lib/rialto/etl/transformers/people.rb
+++ b/lib/rialto/etl/transformers/people.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rialto/etl/transformers/people/positions'
+
+module Rialto
+  module Etl
+    module Transformers
+      # Transformers for the CAP Person API
+      module People
+        # Transform titles from the CAP people api response to positions in the IR
+        # @param titles [Array] a list of titles the person has
+        # @param profile_id [String] the identifier for the person profile
+        # @return [Array<Hash>] a list of vivo positions described in our IR
+        def self.construct_positions(titles:, profile_id:)
+          Positions.new.construct_positions(titles: titles, profile_id: profile_id)
+        end
+      end
+    end
+  end
+end

--- a/lib/rialto/etl/transformers/people/positions.rb
+++ b/lib/rialto/etl/transformers/people/positions.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rialto/etl/namespaces'
+
+module Rialto
+  module Etl
+    module Transformers
+      module People
+        # Position transformer for the CAP Person API
+        class Positions
+          include Rialto::Etl::Vocabs
+
+          # Transform titles from the CAP people api response to positions in the IR
+          # @param titles [Array] a list of titles the person has
+          # @param profile_id [String] the identifier for the person profile
+          # @return [Array<Hash>] a list of vivo positions described in our IR
+          def construct_positions(titles:, profile_id:)
+            Array(titles).map do |title_json|
+              org_code = title_json['organization']['orgCode']
+              position_for(org_code: org_code,
+                           hr_title: title_json['title'],
+                           label: title_json['label']['text'],
+                           profile_id: profile_id)
+            end
+          end
+
+          private
+
+          # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+          def position_for(org_code:, hr_title:, label:, profile_id:)
+            {
+              '@id' => RIALTO_CONTEXT_POSITIONS["#{org_code}_#{profile_id}"],
+              '@type' => VIVO['Position'],
+              "!#{DCTERMS['valid']}" => true,
+              DCTERMS['valid'].to_s => Time.now.to_date,
+              VIVO['relates'].to_s => [RIALTO_PEOPLE[profile_id], {
+                '@id' => RIALTO_ORGANIZATIONS[orgs_map[org_code]],
+                VIVO['relatedBy'].to_s => RIALTO_CONTEXT_POSITIONS["#{org_code}_#{profile_id}"]
+              }],
+              "!#{VIVO['hrJobTitle']}" => true,
+              VIVO['hrJobTitle'].to_s => hr_title,
+              "!#{RDFS['label']}" => true,
+              RDFS['label'].to_s => label
+            }
+          end
+          # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+          def orgs_map
+            @orgs_map ||= Traject::TranslationMap.new('stanford_org_codes_to_organizations')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/configs/stanford_organizations_to_sparql_statements_spec.rb
+++ b/spec/configs/stanford_organizations_to_sparql_statements_spec.rb
@@ -131,7 +131,6 @@ RSpec.describe Rialto::Etl::Transformer do
       before do
         transform(STANFORD_ORGS_INSERT)
       end
-      # rubocop:disable RSpec/MultipleExpectations
       it 'is inserted with org triples' do
         # 3 organizations
         query = client.select(count: { org: :c })
@@ -211,8 +210,6 @@ RSpec.describe Rialto::Etl::Transformer do
                        .true?
         expect(result).to be true
       end
-
-      # rubocop:enable RSpec/MultipleExpectations
     end
 
     describe 'add and delete orgs' do
@@ -236,7 +233,6 @@ RSpec.describe Rialto::Etl::Transformer do
         transform(STANFORD_ORGS_INSERT)
         transform(STANFORD_ORGS_UPDATE)
       end
-      # rubocop:disable RSpec/MultipleExpectations
       it 'updates the org' do
         # Changes org type
         result = client.ask
@@ -319,8 +315,6 @@ RSpec.describe Rialto::Etl::Transformer do
         expect(result).to be true
 
         # TODO: Test change children
-
-        # rubocop:enable RSpec/MultipleExpectations
       end
     end
   end

--- a/spec/configs/stanford_people_to_list_spec.rb
+++ b/spec/configs/stanford_people_to_list_spec.rb
@@ -53,15 +53,12 @@ RSpec.describe Rialto::Etl::Transformer do
       it 'has the right number of lines' do
         expect(csv.length).to eq(3)
       end
-
-      # rubocop:disable RSpec/MultipleExpectations
       it 'includes the correct Stanford people' do
         expect(csv[1][0]).to eq("#{Rialto::Etl::Vocabs::RIALTO_PEOPLE}400150")
         expect(csv[1][1]).to eq('Bill')
         expect(csv[1][2]).to eq('Chen')
         expect(csv[1][3]).to eq('billchen1')
       end
-      # rubocop:enable RSpec/MultipleExpectations
     end
   end
 end

--- a/spec/configs/stanford_people_to_sparql_statements_spec.rb
+++ b/spec/configs/stanford_people_to_sparql_statements_spec.rb
@@ -226,7 +226,6 @@ RSpec.describe Rialto::Etl::Transformer do
       before do
         transform(STANFORD_PERSON_INSERT)
       end
-      # rubocop:disable RSpec/MultipleExpectations
       it 'is inserted with person triples' do
         # Test 3 people
         query = client.select(count: { org: :c })
@@ -481,14 +480,12 @@ RSpec.describe Rialto::Etl::Transformer do
                        .true?
         expect(result).to be true
       end
-      # rubocop:enable RSpec/MultipleExpectations
     end
     describe 'update person' do
       before do
         transform(STANFORD_PERSON_INSERT)
         transform(STANFORD_PERSON_UPDATE)
       end
-      # rubocop:disable RSpec/MultipleExpectations
       it 'updates the person' do
         # Test 4 people (removed 2 advisees and added one)
         query = client.select(count: { org: :c })
@@ -608,7 +605,6 @@ RSpec.describe Rialto::Etl::Transformer do
                        .true?
         expect(result).to be true
       end
-      # rubocop:enable RSpec/MultipleExpectations
     end
   end
 end

--- a/spec/transformers/people_spec.rb
+++ b/spec/transformers/people_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rialto/etl/transformers/people'
+
+RSpec.describe Rialto::Etl::Transformers::People do
+  describe '.construct_positions' do
+    subject(:positions) { described_class.construct_positions(titles: titles, profile_id: id) }
+
+    let(:id) { '123' }
+
+    context 'when titles are present' do
+      let(:titles) do
+        [{
+          'label' => {
+            'text' => 'UX Designer, SoM - Information Resources & Technology'
+          },
+          'organization' => {
+            'orgCode' => 'VRTS'
+          },
+          'title' => 'UX Designer'
+        }]
+      end
+
+      it 'returns positions' do
+        position = positions.first
+        expect(position['@id']).to eq RDF::URI('http://sul.stanford.edu/rialto/context/positions/VRTS_123')
+        expect(position['@type']).to eq RDF::URI('http://vivoweb.org/ontology/core#Position')
+        expect(position['http://vivoweb.org/ontology/core#relates'][0])
+          .to eq RDF::URI('http://sul.stanford.edu/rialto/agents/people/123')
+        expect(position['http://vivoweb.org/ontology/core#relates'][1])
+          .to include('@id' => RDF::URI('http://sul.stanford.edu/rialto/agents/orgs/school-of-medicine/deans-office/information-resources-and-technology-irt/it-services'))
+      end
+    end
+
+    context 'when titles are nil' do
+      let(:titles) { nil }
+
+      it 'returns positions' do
+        expect(positions).to eq []
+      end
+    end
+  end
+end

--- a/spec/writers/sparql_statement_writer_spec.rb
+++ b/spec/writers/sparql_statement_writer_spec.rb
@@ -44,8 +44,6 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
       expect(repository.size).to eq(0)
     end
   end
-
-  # rubocop:disable RSpec/MultipleExpectations
   describe '#values_to_delete_insert' do
     it 'produces insert data only when delete is false' do
       statements = writer.values_to_delete_insert(Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'],
@@ -90,7 +88,6 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
       expect(repository).to have_same_triples(graph)
     end
   end
-  # rubocop:enable RSpec/MultipleExpectations
 
   describe '#serialize' do
     it 'handles @ and non-@ fields' do


### PR DESCRIPTION
For some people the API was returning no positions.  This prevents a
null pointer error when this happens.