### PR TITLE
Add retries and stop using concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ exe/load call Sparql -i organizations.sparql
 ### Pipeline to harvest Researchers from Stanford
 
 Notes:
-* This takes about 20 min as it has to make ~796 requests to get the full
+* The extract step takes about 20 min as it has to make ~796 requests to get the full
 1.6GB of data.
 * The transform step depends on `organizations.json` from organizations pipeline.
+* The transform step takes about 13 minutes on a single thread
 
 ```
 exe/extract call StanfordResearchers > researchers.ndj

--- a/lib/rialto/etl/configs/sparql.rb
+++ b/lib/rialto/etl/configs/sparql.rb
@@ -6,4 +6,5 @@ settings do
   provide 'writer_class_name', 'Rialto::Etl::Writers::SparqlWriter'
   provide 'reader_class_name', 'Rialto::Etl::Readers::SparqlStatementReader'
   provide 'sparql_writer.update_url', ::Settings.sparql_writer.update_url
+  provide 'sparql_writer.thread_pool', 0
 end


### PR DESCRIPTION
These measures help workaround ConcurrentModificationExceptions that
Neptune occasionally issues.