### PR TITLE
Switch to SeRA stanford-only scope.

### DIFF
--- a/lib/rialto/etl/extractors/sera.rb
+++ b/lib/rialto/etl/extractors/sera.rb
@@ -56,7 +56,7 @@ module Rialto
 
         # @return [String] the path for the API request for the given sunetid
         def url
-          "/mais/sera/v1/api?scope=sera.public&sunetId=#{sunetid}"
+          "/mais/sera/v1/api?scope=sera.stanford-only&sunetId=#{sunetid}"
         end
 
         # @return [Faraday::Response]

--- a/spec/extractors/sera_spec.rb
+++ b/spec/extractors/sera_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Rialto::Etl::Extractors::Sera do
       before do
         stub_request(:post, 'https://aswsuat.stanford.edu/api/oauth/token')
           .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: token_response)
-        stub_request(:get, 'https://aswsuat.stanford.edu/mais/sera/v1/api?scope=sera.public&sunetId=altman')
+        stub_request(:get, 'https://aswsuat.stanford.edu/mais/sera/v1/api?scope=sera.stanford-only&sunetId=altman')
           .to_return(status: 401, body: '', headers: {})
         # allow(extractor).to receive(:client).and_raise(error_message)
       end
@@ -39,7 +39,7 @@ RSpec.describe Rialto::Etl::Extractors::Sera do
           .to_return(status: 200, headers: { 'Content-Type' => 'application/json' },
                      body: token_response)
 
-        stub_request(:get, 'https://aswsuat.stanford.edu/mais/sera/v1/api?scope=sera.public&sunetId=altman')
+        stub_request(:get, 'https://aswsuat.stanford.edu/mais/sera/v1/api?scope=sera.stanford-only&sunetId=altman')
           .with(headers: { 'Authorization' => 'Bearer ABCD123' })
           .to_return(status: 200, body: body, headers: {})
         allow(extractor.send(:client)).to receive(:page_size).and_return(2)
@@ -59,7 +59,7 @@ RSpec.describe Rialto::Etl::Extractors::Sera do
           .to_return(status: 200, headers: { 'Content-Type' => 'application/json' },
                      body: token_response)
 
-        stub_request(:get, 'https://aswsuat.stanford.edu/mais/sera/v1/api?scope=sera.public&sunetId=altman')
+        stub_request(:get, 'https://aswsuat.stanford.edu/mais/sera/v1/api?scope=sera.stanford-only&sunetId=altman')
           .with(headers: { 'Authorization' => 'Bearer ABCD123' })
           .to_return(status: 404, body: '', headers: {})
         allow(extractor.send(:client)).to receive(:page_size).and_return(2)


### PR DESCRIPTION
We need to know which agency is funding a grant. This information is not available in the public scope that we're currently using. I've spoken with @peetucket about this switch, and he's OK with it.