### PR TITLE
Grants extractor should retry only when specific exceptions are raised

### DIFF
--- a/lib/rialto/etl/cli/grants.rb
+++ b/lib/rialto/etl/cli/grants.rb
@@ -69,7 +69,10 @@ module Rialto
           File.open(output_file, 'w') do |f|
             f.write(results.join("\n"))
           end
-        rescue RuntimeError, SocketError, Errno::ECONNRESET => exception
+        rescue Rialto::Etl::Extractors::Sera::ConnectionError,
+               SocketError,
+               Faraday::TimeoutError,
+               Faraday::ConnectionFailed => exception
           say "retrying #{id}, failed with #{exception.class}: #{exception.message}"
           retry
         rescue StandardError => exception

--- a/lib/rialto/etl/extractors/sera.rb
+++ b/lib/rialto/etl/extractors/sera.rb
@@ -8,6 +8,9 @@ module Rialto
     module Extractors
       # Documentation: https://asconfluence.stanford.edu/confluence/display/MaIS/SeRA+API+-+User+Documentation
       class Sera
+        # Instead of a bare `raise`, raise a custom error so it can be caught reliably
+        class ConnectionError < StandardError; end
+
         def initialize(options = {})
           @sunetid = options.fetch(:sunetid)
         end
@@ -45,7 +48,7 @@ module Rialto
           when 404
             []
           when 400..499, 500..599
-            raise "There was a problem with the request to `#{url}` (#{response.status}): #{response.body}"
+            raise ConnectionError, "There was a problem with the request to `#{url}` (#{response.status}): #{response.body}"
           else
             hash = JSON.parse(response.body)
             hash['SeRARecord']

--- a/spec/extractors/sera_spec.rb
+++ b/spec/extractors/sera_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Rialto::Etl::Extractors::Sera do
       end
 
       it 'raises the exception' do
-        expect { extractor.each {} }.to raise_error(StandardError, /There was a problem with the request/)
+        expect { extractor.each {} }.to raise_error(Rialto::Etl::Extractors::Sera::ConnectionError,
+                                                    /There was a problem with the request/)
       end
     end
 


### PR DESCRIPTION
Now that the script has been running for a day, I have had a chance to see the specific exception classes that are `raise`d, and I am updating the script to `rescue` these classes specifically. (`RuntimeError` is a bit vague, and `Errno::ECONNRESET` does not appear to be `raise`d; Faraday exceptions *are* being `raise`d.)

Note: I briefly considered stuffing the new `ConnectionError` into a new higher-level module (`Rialto::Etl::Errors` or `Rialto::Etl::Extractors::Errors` or some such), but then thought that was premature (bc YAGNI?) since this error class is only being used within the SeRA context. I'd say we can/should move the exception class if/when we broaden its usage.