### PR TITLE
Use strict vocabularies

### DIFF
--- a/lib/rialto/etl/configs/stanford_organizations_to_sparql_statements.rb
+++ b/lib/rialto/etl/configs/stanford_organizations_to_sparql_statements.rb
@@ -30,7 +30,7 @@ to_field '@id', lambda { |json, accum|
 
 # Org types
 to_field '@type', lambda { |json, accum|
-  org_types = [FOAF.Agent, FOAF['Organization']]
+  org_types = [RDF::Vocab::FOAF.Agent, RDF::Vocab::FOAF.Organization]
   org_types << case JsonPath.on(json, '$.type').first
                when 'DEPARTMENT'
                  VIVO['Department']
@@ -49,22 +49,22 @@ to_field '@type', lambda { |json, accum|
 }
 
 # Org label
-to_field '!' + SKOS['prefLabel'].to_s, literal(true)
-to_field SKOS['prefLabel'].to_s, lambda { |json, accum|
+to_field '!' + RDF::Vocab::SKOS.prefLabel.to_s, literal(true)
+to_field RDF::Vocab::SKOS.prefLabel.to_s, lambda { |json, accum|
   accum << contextualized_org_name(json)
 }
-to_field '!' + RDFS['label'].to_s, literal(true)
-to_field RDFS['label'].to_s, lambda { |json, accum|
+to_field "!#{RDF::Vocab::RDFS.label}", literal(true)
+to_field RDF::Vocab::RDFS.label.to_s, lambda { |json, accum|
   accum << contextualized_org_name(json)
 }
 
 # Org codes
-to_field '!' + DCTERMS.identifier.to_s, literal(true)
-to_field DCTERMS.identifier.to_s, extract_json('$.orgCodes'), single: true
+to_field '!' + RDF::Vocab::DC.identifier.to_s, literal(true)
+to_field RDF::Vocab::DC.identifier.to_s, extract_json('$.orgCodes'), single: true
 
 # Parent
-to_field '!' + OBO['BFO_0000050'].to_s, literal(true)
-to_field OBO['BFO_0000050'].to_s, lambda { |json, accum|
+to_field "!#{OBO.BFO_0000050}", literal(true)
+to_field OBO.BFO_0000050.to_s, lambda { |json, accum|
   parent = JsonPath.on(json, '$.parent.alias').first
   accum << RIALTO_ORGANIZATIONS[parent] if parent
 }

--- a/lib/rialto/etl/configs/wos_to_sparql_statements.rb
+++ b/lib/rialto/etl/configs/wos_to_sparql_statements.rb
@@ -80,16 +80,16 @@ to_field '@type',
   accumulator.map! { |type| RDF::URI.new(type) }
 end
 
-to_field '@type', literal(BIBO['Document'])
+to_field '@type', literal(RDF::Vocab::BIBO.Document)
 
-to_field "!#{BIBO['abstract']}", literal(true), single: true
-to_field BIBO['abstract'].to_s, lambda { |json, accumulator|
+to_field "!#{RDF::Vocab::BIBO.abstract}", literal(true), single: true
+to_field RDF::Vocab::BIBO.abstract.to_s, lambda { |json, accumulator|
   abstracts = JsonPath.on(json, '$.static_data.fullrecord_metadata.abstracts.abstract.abstract_text.p')
   accumulator << abstracts.flatten.join(' ') unless abstracts.empty?
 }, single: true
 
-to_field "!#{BIBO['doi']}", literal(true), single: true
-to_field BIBO['doi'].to_s, lambda { |json, accumulator|
+to_field "!#{RDF::Vocab::BIBO.doi}", literal(true), single: true
+to_field RDF::Vocab::BIBO.doi.to_s, lambda { |json, accumulator|
   doi = JsonPath.on(json, '$.dynamic_data.cluster_related.identifiers.identifier[?(@.type=="doi")].value').first ||
         JsonPath.on(json, '$.dynamic_data.cluster_related.identifiers.identifier[?(@.type=="xref_doi")].value').first
   accumulator << doi if doi
@@ -116,7 +116,7 @@ to_field VIVO['relatedBy'].to_s, lambda { |json, accumulator|
     if address && address.key?('country')
       address_vcard = Rialto::Etl::Transformers::People.construct_address_vcard("#{person_id}_#{json['UID']}",
                                                                                 country: address['country'])
-      person[VCARD['hasAddress'].to_s] = address_vcard
+      person[RDF::Vocab::VCARD.hasAddress.to_s] = address_vcard
     end
 
     # If there is an organization, add a position for the person
@@ -138,22 +138,23 @@ to_field VIVO['relatedBy'].to_s, lambda { |json, accumulator|
 }, single: true
 # rubocop:enable Metrics/BlockLength
 
-to_field "!#{DCTERMS['subject']}", literal(true), single: true
-to_field DCTERMS['subject'].to_s, lambda { |json, accumulator|
+to_field "!#{RDF::Vocab::DC.subject}", literal(true), single: true
+to_field RDF::Vocab::DC.subject.to_s, lambda { |json, accumulator|
   subjects = JsonPath.on(json, '$.static_data.fullrecord_metadata.category_info.subjects.' \
      "subject[?(@.ascatype=='extended')].content")
   accumulator << subjects.map do |subject|
     resolve_entity('topic', name: subject) || { '@id' => RIALTO_CONCEPTS[Digest::MD5.hexdigest(subject.downcase)],
-                                                '@type' => SKOS['Concept'], DCTERMS['subject'].to_s => subject }
+                                                '@type' => RDF::Vocab::SKOS.Concept,
+                                                RDF::Vocab::DC.subject.to_s => subject }
   end
 }, single: true
 
-to_field "!#{BIBO['identifier']}", literal(true), single: true
-to_field BIBO['identifier'].to_s,
+to_field "!#{RDF::Vocab::BIBO.identifier}", literal(true), single: true
+to_field RDF::Vocab::BIBO.identifier.to_s,
          extract_json('$.dynamic_data.cluster_related.identifiers.identifier[*].value')
 
-to_field "!#{DCTERMS['isPartOf']}", literal(true), single: true
-to_field DCTERMS['isPartOf'].to_s,
+to_field "!#{RDF::Vocab::DC.isPartOf}", literal(true), single: true
+to_field RDF::Vocab::DC.isPartOf.to_s,
          extract_json("$.static_data.summary.titles.title[?(@.type=='source')].content"),
          single: true
 
@@ -162,12 +163,12 @@ to_field VIVO['publisher'].to_s,
          extract_json('$.static_data.summary.publishers.publisher.names.name.display_name'),
          single: true
 
-to_field "!#{DCTERMS['title']}", literal(true), single: true
-to_field DCTERMS['title'].to_s,
+to_field "!#{RDF::Vocab::DC.title}", literal(true), single: true
+to_field RDF::Vocab::DC.title.to_s,
          extract_json("$.static_data.summary.titles.title[?(@.type=='item')].content"),
          single: true
 
-to_field "!#{DCTERMS['created']}", literal(true), single: true
-to_field DCTERMS['created'].to_s,
+to_field "!#{RDF::Vocab::DC.created}", literal(true), single: true
+to_field RDF::Vocab::DC.created.to_s,
          extract_json('$.static_data.summary.pub_info.sortdate'),
          single: true

--- a/lib/rialto/etl/namespaces.rb
+++ b/lib/rialto/etl/namespaces.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rdf'
+require 'rdf/vocab'
 
 module Rialto
   module Etl
@@ -21,15 +22,38 @@ module Rialto
       RIALTO_CONTEXT_ROLES = RDF::Vocabulary.new(rialto_base + 'context/roles/')
       RIALTO_CONTEXT_IDENTIFIERS = RDF::Vocabulary.new(rialto_base + 'context/identifiers/')
       RIALTO_CONTEXT_POSITIONS = RDF::Vocabulary.new(rialto_base + 'context/positions/')
-      SKOS = RDF::Vocabulary.new('http://www.w3.org/2004/02/skos/core#')
-      VCARD = RDF::Vocabulary.new('http://www.w3.org/2006/vcard/ns#')
-      FOAF = RDF::Vocabulary.new('http://xmlns.com/foaf/0.1/')
-      VIVO = RDF::Vocabulary.new('http://vivoweb.org/ontology/core#')
-      DCTERMS = RDF::Vocabulary.new('http://purl.org/dc/terms/')
-      OBO = RDF::Vocabulary.new('http://purl.obolibrary.org/obo/')
-      RDFS = RDF::Vocabulary.new('http://www.w3.org/2000/01/rdf-schema#')
-      BIBO = RDF::Vocabulary.new('http://purl.org/ontology/bibo/')
-      GEONAMES = RDF::Vocabulary.new('http://sws.geonames.org/')
+
+      # The VIVO ontology
+      class VIVO < RDF::StrictVocabulary('http://vivoweb.org/ontology/core#')
+        term :AdviseeRole
+        term :AdvisingRelationship
+        term :AdvisorRole
+        term :Authorship
+        term :Department
+        term :Division
+        term :Editorship
+        term :FacultyMember
+        term :Librarian
+        term :NonAcademic
+        term :Position
+        term :Student
+        term :University
+
+        property :hrJobTitle
+        property :overview
+        property :publisher
+        property :relates
+        property :relatedBy
+      end
+
+      # Basic Formal Ontology designed for use in supporting information retrieval,
+      # analysis and integration in scientific and other domains
+      class OBO < RDF::StrictVocabulary('http://purl.obolibrary.org/obo/')
+        property :BFO_0000050
+        property :RO_0000052
+        property :RO_0000053
+      end
+      SWS_GEONAMES = RDF::Vocabulary.new('http://sws.geonames.org/')
     end
     # Holds graph names
     module NamedGraphs

--- a/lib/rialto/etl/transformers/organizations.rb
+++ b/lib/rialto/etl/transformers/organizations.rb
@@ -13,9 +13,9 @@ module Rialto
         def self.construct_org(org_name:)
           {
             '@id' => Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS[Digest::MD5.hexdigest(org_name.downcase)],
-            '@type' => [Rialto::Etl::Vocabs::FOAF['Agent'], Rialto::Etl::Vocabs::FOAF['Organization']],
-            Rialto::Etl::Vocabs::SKOS['prefLabel'].to_s => org_name,
-            Rialto::Etl::Vocabs::RDFS['label'].to_s => org_name
+            '@type' => [RDF::Vocab::FOAF.Agent, RDF::Vocab::FOAF.Organization],
+            RDF::Vocab::SKOS.prefLabel.to_s => org_name,
+            RDF::RDFS.label.to_s => org_name
           }
         end
 

--- a/lib/rialto/etl/transformers/people.rb
+++ b/lib/rialto/etl/transformers/people.rb
@@ -78,14 +78,14 @@ module Rialto
                                                             family_name: family_name)
           {
             '@id' => Rialto::Etl::Vocabs::RIALTO_PEOPLE[id],
-            '@type' => [Rialto::Etl::Vocabs::FOAF['Agent'], Rialto::Etl::Vocabs::FOAF['Person']],
-            Rialto::Etl::Vocabs::SKOS['prefLabel'].to_s => full_name,
-            Rialto::Etl::Vocabs::RDFS['label'].to_s => full_name,
+            '@type' => [RDF::Vocab::FOAF.Agent, RDF::Vocab::FOAF.Person],
+            RDF::Vocab::SKOS.prefLabel.to_s => full_name,
+            RDF::Vocab::RDFS.label.to_s => full_name,
             # Name VCard
-            Rialto::Etl::Vocabs::VCARD['hasName'].to_s => names_constructor.construct_name_vcard(id: id,
-                                                                                                 given_name: given_name,
-                                                                                                 middle_name: middle_name,
-                                                                                                 family_name: family_name)
+            RDF::Vocab::VCARD.hasName.to_s => names_constructor.construct_name_vcard(id: id,
+                                                                                     given_name: given_name,
+                                                                                     middle_name: middle_name,
+                                                                                     family_name: family_name)
           }
         end
         # rubocop:enable Metrics/MethodLength

--- a/lib/rialto/etl/transformers/people/addresses.rb
+++ b/lib/rialto/etl/transformers/people/addresses.rb
@@ -24,14 +24,14 @@ module Rialto
           def construct_address_vcard(id, street_address:, locality:, region:, postal_code:, country:)
             vcard = default_hash
             vcard['@id'] = RIALTO_CONTEXT_ADDRESSES[id]
-            vcard[VCARD['street-address'].to_s] = street_address if street_address
-            vcard[VCARD['locality'].to_s] = locality if locality
-            vcard[VCARD['region'].to_s] = region if region
-            vcard[VCARD['postal-code'].to_s] = postal_code if postal_code
+            vcard[RDF::Vocab::VCARD['street-address'].to_s] = street_address if street_address
+            vcard[RDF::Vocab::VCARD.locality.to_s] = locality if locality
+            vcard[RDF::Vocab::VCARD.region.to_s] = region if region
+            vcard[RDF::Vocab::VCARD['postal-code'].to_s] = postal_code if postal_code
             if country
-              vcard[VCARD['country-name'].to_s] = country
+              vcard[RDF::Vocab::VCARD['country-name'].to_s] = country
               if (geocode_id = geocode_id_for(country))
-                vcard[DCTERMS['spatial'].to_s] = GEONAMES["#{geocode_id}/"]
+                vcard[RDF::Vocab::DC.spatial.to_s] = SWS_GEONAMES["#{geocode_id}/"]
               end
             end
             vcard
@@ -42,13 +42,13 @@ module Rialto
 
           def default_hash
             {
-              '@type' => VCARD['Address'],
-              "!#{VCARD['street-address']}" => true,
-              "!#{VCARD['locality']}" => true,
-              "!#{VCARD['region']}" => true,
-              "!#{VCARD['country-name']}" => true,
-              "!#{VCARD['postal-code']}" => true,
-              "!#{DCTERMS['spatial']}" => true
+              '@type' => RDF::Vocab::VCARD.Address,
+              "!#{RDF::Vocab::VCARD['street-address']}" => true,
+              "!#{RDF::Vocab::VCARD.locality}" => true,
+              "!#{RDF::Vocab::VCARD.region}" => true,
+              "!#{RDF::Vocab::VCARD['country-name']}" => true,
+              "!#{RDF::Vocab::VCARD['postal-code']}" => true,
+              "!#{RDF::Vocab::DC.spatial}" => true
             }
           end
 

--- a/lib/rialto/etl/transformers/people/names.rb
+++ b/lib/rialto/etl/transformers/people/names.rb
@@ -9,8 +9,6 @@ module Rialto
       module People
         # Name transformer
         class Names
-          include Rialto::Etl::Vocabs
-
           # Transform names into the hash for an address Vcard
           # @param id [String] an id to use to construct the Vcard URI. If omitted, one will be constructed.
           # @param given_name [String] first name
@@ -19,15 +17,15 @@ module Rialto
           # @return [Hash] a hash representing the Vcard
           def construct_name_vcard(id:, given_name:, middle_name: nil, family_name:)
             vcard = {
-              '@id' => RIALTO_CONTEXT_NAMES[id || id_from_names(given_name, family_name)],
-              '@type' => VCARD['Name'],
-              "!#{VCARD['given-name']}" => true,
-              VCARD['given-name'].to_s => given_name,
-              "!#{VCARD['middle-name']}" => true,
-              "!#{VCARD['family-name']}" => true,
-              VCARD['family-name'].to_s => family_name
+              '@id' => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES[id || id_from_names(given_name, family_name)],
+              '@type' => RDF::Vocab::VCARD.Name,
+              "!#{RDF::Vocab::VCARD['given-name']}" => true,
+              RDF::Vocab::VCARD['given-name'].to_s => given_name,
+              "!#{RDF::Vocab::VCARD['additional-name']}" => true,
+              "!#{RDF::Vocab::VCARD['family-name']}" => true,
+              RDF::Vocab::VCARD['family-name'].to_s => family_name
             }
-            vcard[VCARD['middle-name'].to_s] = middle_name if middle_name
+            vcard[RDF::Vocab::VCARD['additional-name'].to_s] = middle_name if middle_name
             vcard
           end
 

--- a/lib/rialto/etl/transformers/people/positions.rb
+++ b/lib/rialto/etl/transformers/people/positions.rb
@@ -73,16 +73,16 @@ module Rialto
 
             }
             if valid
-              position["!#{DCTERMS['valid']}"] = true
-              position[DCTERMS['valid'].to_s] = Time.now.to_date
+              position["!#{RDF::Vocab::DC.valid}"] = true
+              position[RDF::Vocab::DC.valid.to_s] = Time.now.to_date
             end
             if hr_title
               position["!#{VIVO['hrJobTitle']}"] = true
               position[VIVO['hrJobTitle'].to_s] = hr_title
             end
             if label
-              position["!#{RDFS['label']}"] = true
-              position[RDFS['label'].to_s] = label
+              position["!#{RDF::RDFS.label}"] = true
+              position[RDF::RDFS.label.to_s] = label
             end
 
             position

--- a/rialto-etl.gemspec
+++ b/rialto-etl.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'oauth2', '~> 1.4'
   spec.add_dependency 'parallel'
   spec.add_dependency 'rdf'
+  spec.add_dependency 'rdf-vocab'
   spec.add_dependency 'ruby-progressbar'
   spec.add_dependency 'sparql'
   spec.add_dependency 'sparql-client', '~> 3.0'

--- a/spec/configs/stanford_organizations_to_sparql_statements_spec.rb
+++ b/spec/configs/stanford_organizations_to_sparql_statements_spec.rb
@@ -135,8 +135,8 @@ RSpec.describe Rialto::Etl::Transformer do
         # 3 organizations
         query = client.select(count: { org: :c })
                       .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
-                      .where([:org, RDF.type, Rialto::Etl::Vocabs::FOAF['Organization']])
-                      .where([:org, RDF.type, Rialto::Etl::Vocabs::FOAF['Agent']])
+                      .where([:org, RDF.type, RDF::Vocab::FOAF.Organization])
+                      .where([:org, RDF.type, RDF::Vocab::FOAF.Agent])
         expect(query.solutions.first[:c].to_i).to eq(3)
 
         # Org URI correct
@@ -152,7 +152,7 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                          'education-and-recreation/other-daper-administration'],
-                                 Rialto::Etl::Vocabs::SKOS['prefLabel'],
+                                 RDF::Vocab::SKOS.prefLabel,
                                  'Other DAPER Administration (Physical Education and Recreation)'])
                        .true?
         expect(result).to be true
@@ -162,7 +162,7 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::OBO['BFO_0000050'],
+                                 Rialto::Etl::Vocabs::OBO.BFO_0000050,
                                  Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['stanford']])
                        .true?
         expect(result).to be true
@@ -174,7 +174,7 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::SKOS['prefLabel'],
+                                 RDF::Vocab::SKOS.prefLabel,
                                  'Physical Education and Recreation'])
                        .true?
         expect(result).to be true
@@ -184,11 +184,11 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::DCTERMS.identifier,
+                                 RDF::Vocab::DC.identifier,
                                  'LVTK'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::DCTERMS.identifier,
+                                 RDF::Vocab::DC.identifier,
                                  'LVRC'])
                        .true?
         expect(result).to be true
@@ -222,8 +222,8 @@ RSpec.describe Rialto::Etl::Transformer do
         # 4 organizations
         query = client.select(count: { org: :c })
                       .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
-                      .where([:org, RDF.type, Rialto::Etl::Vocabs::FOAF['Organization']])
-                      .where([:org, RDF.type, Rialto::Etl::Vocabs::FOAF['Agent']])
+                      .where([:org, RDF.type, RDF::Vocab::FOAF.Organization])
+                      .where([:org, RDF.type, RDF::Vocab::FOAF.Agent])
         expect(query.solutions.first[:c].to_i).to eq(4)
       end
     end
@@ -257,7 +257,7 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::SKOS['prefLabel'],
+                                 RDF::Vocab::SKOS.prefLabel,
                                  'Physical Education and Recreation'])
                        .true?
         expect(result).to be false
@@ -265,7 +265,7 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::SKOS['prefLabel'],
+                                 RDF::Vocab::SKOS.prefLabel,
                                  'Physical Education and Recreational Lounging (Amherst College)'])
                        .true?
         expect(result).to be true
@@ -275,11 +275,11 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-education'\
                           '-and-recreation'],
-                                 Rialto::Etl::Vocabs::DCTERMS.identifier,
+                                 RDF::Vocab::DC.identifier,
                                  'LVTK'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::DCTERMS.identifier,
+                                 RDF::Vocab::DC.identifier,
                                  'LVRC'])
                        .true?
         expect(result).to be false
@@ -287,11 +287,11 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::DCTERMS.identifier,
+                                 RDF::Vocab::DC.identifier,
                                  'LVTK'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::DCTERMS.identifier,
+                                 RDF::Vocab::DC.identifier,
                                  'LVRX'])
                        .true?
         expect(result).to be true
@@ -301,7 +301,7 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::OBO['BFO_0000050'],
+                                 Rialto::Etl::Vocabs::OBO.BFO_0000050,
                                  Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['stanford']])
                        .true?
         expect(result).to be false
@@ -309,7 +309,7 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_ORGANIZATIONS_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['department-of-athletics-physical-'\
                           'education-and-recreation'],
-                                 Rialto::Etl::Vocabs::OBO['BFO_0000050'],
+                                 Rialto::Etl::Vocabs::OBO.BFO_0000050,
                                  Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['amherst']])
                        .true?
         expect(result).to be true

--- a/spec/configs/stanford_people_to_sparql_statements_spec.rb
+++ b/spec/configs/stanford_people_to_sparql_statements_spec.rb
@@ -230,15 +230,15 @@ RSpec.describe Rialto::Etl::Transformer do
         # Test 3 people
         query = client.select(count: { org: :c })
                       .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
-                      .where([:org, RDF.type, Rialto::Etl::Vocabs::FOAF['Person']])
-                      .where([:org, RDF.type, Rialto::Etl::Vocabs::FOAF['Agent']])
+                      .where([:org, RDF.type, RDF::Vocab::FOAF.Person])
+                      .where([:org, RDF.type, RDF::Vocab::FOAF.Agent])
         expect(query.solutions.first[:c].to_i).to eq(3)
 
         # Test label
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150'],
-                                 Rialto::Etl::Vocabs::SKOS['prefLabel'],
+                                 RDF::Vocab::SKOS.prefLabel,
                                  'Bill Chen'])
                        .true?
         expect(result).to be true
@@ -247,24 +247,24 @@ RSpec.describe Rialto::Etl::Transformer do
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['hasName'],
+                                 RDF::Vocab::VCARD['hasName'],
                                  Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['400150']])
                        .true?
         expect(result).to be true
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['given-name'],
+                                 RDF::Vocab::VCARD['given-name'],
                                  'Bill'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['family-name'],
+                                 RDF::Vocab::VCARD['family-name'],
                                  'Chen'])
                        .true?
         expect(result).to be true
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['middle-name'],
+                                 RDF::Vocab::VCARD['additional-name'],
                                  :o])
                        .true?
         expect(result).to be false
@@ -299,7 +299,7 @@ RSpec.describe Rialto::Etl::Transformer do
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['hasAddress'],
+                                 RDF::Vocab::VCARD['hasAddress'],
                                  Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150']])
                        .true?
         expect(result).to be true
@@ -307,27 +307,26 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
                                  RDF.type,
-                                 Rialto::Etl::Vocabs::VCARD['Address']])
+                                 RDF::Vocab::VCARD.Address])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['street-address'],
+                                 RDF::Vocab::VCARD['street-address'],
                                  'Tresidder Memorial Union,, 2nd Floor, Suite 4, 459 Lagunita Drive'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['locality'],
+                                 RDF::Vocab::VCARD['locality'],
                                  'Stanford'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['region'],
+                                 RDF::Vocab::VCARD['region'],
                                  'California'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['postal-code'],
+                                 RDF::Vocab::VCARD['postal-code'],
                                  '94305-3073'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['country-name'],
+                                 RDF::Vocab::VCARD['country-name'],
                                  'United States'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::DCTERMS['spatial'],
+                                 RDF::Vocab::DC.spatial,
                                  RDF::URI.new('http://sws.geonames.org/6252001/')])
-                       .true?
-        expect(result).to be true
+        expect(result).to be_true
       end
 
       it 'is inserted with advisee triples' do
@@ -335,29 +334,26 @@ RSpec.describe Rialto::Etl::Transformer do
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'],
-                                 Rialto::Etl::Vocabs::SKOS['prefLabel'],
+                                 RDF::Vocab::SKOS.prefLabel,
                                  'Lyuqin Cao'])
-                       .true?
-        expect(result).to be true
+        expect(result).to be_true
 
         # Test advisee name vcard
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'],
-                                 Rialto::Etl::Vocabs::VCARD['hasName'],
+                                 RDF::Vocab::VCARD['hasName'],
                                  Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['188882']])
-                       .true?
-        expect(result).to be true
+        expect(result).to be_true
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['188882'],
-                                 Rialto::Etl::Vocabs::VCARD['given-name'],
+                                 RDF::Vocab::VCARD['given-name'],
                                  'Lyuqin'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['188882'],
-                                 Rialto::Etl::Vocabs::VCARD['family-name'],
+                                 RDF::Vocab::VCARD['family-name'],
                                  'Cao'])
-                       .true?
-        expect(result).to be true
+        expect(result).to be_true
 
         # Test advising relationship
         result = client.ask
@@ -372,10 +368,9 @@ RSpec.describe Rialto::Etl::Transformer do
                                  Rialto::Etl::Vocabs::VIVO['relatedBy'],
                                  Rialto::Etl::Vocabs::RIALTO_CONTEXT_RELATIONSHIPS['188882_400150']])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_RELATIONSHIPS['188882_400150'],
-                                 Rialto::Etl::Vocabs::DCTERMS['valid'],
+                                 RDF::Vocab::DC.valid,
                                  RDF::Literal::Date.new(Time.now.to_date)])
-                       .true?
-        expect(result).to be true
+        expect(result).to be_true
 
         # Test advising role
         result = client.ask
@@ -389,8 +384,7 @@ RSpec.describe Rialto::Etl::Transformer do
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ROLES['AdvisorRole'],
                                  Rialto::Etl::Vocabs::OBO['RO_0000052'],
                                  Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150']])
-                       .true?
-        expect(result).to be true
+        expect(result).to be_true
 
         # Test advisee role
         result = client.ask
@@ -404,28 +398,26 @@ RSpec.describe Rialto::Etl::Transformer do
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ROLES['AdviseeRole'],
                                  Rialto::Etl::Vocabs::OBO['RO_0000052'],
                                  Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882']])
-                       .true?
-        expect(result).to be true
+        expect(result).to be_true
 
         # Test person email
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['hasEmail'],
+                                 RDF::Vocab::VCARD.hasEmail,
                                  'billchen1@stanford.edu'])
-                       .true?
-        expect(result).to be true
+        expect(result).to be_true
 
         # Test sunetid
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150'],
-                                 Rialto::Etl::Vocabs::DCTERMS['identifier'],
+                                 RDF::Vocab::DC.identifier,
                                  RDF::Literal.new('billchen1',
                                                   datatype: Rialto::Etl::Vocabs::RIALTO_CONTEXT_IDENTIFIERS['Sunetid'])])
-                       .true?
-        expect(result).to be true
+        expect(result).to be_true
       end
+
       it 'is inserted with position triples' do
         # Test 1 position
         query = client.select(count: { pos: :p })
@@ -457,7 +449,7 @@ RSpec.describe Rialto::Etl::Transformer do
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_POSITIONS['HMGN_400150'],
-                                 Rialto::Etl::Vocabs::DCTERMS['valid'],
+                                 RDF::Vocab::DC.valid,
                                  RDF::Literal::Date.new(Time.now.to_date)])
                        .true?
         expect(result).to be true
@@ -475,7 +467,7 @@ RSpec.describe Rialto::Etl::Transformer do
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_POSITIONS['HMGN_400150'],
-                                 Rialto::Etl::Vocabs::RDFS['label'],
+                                 RDF::Vocab::RDFS.label,
                                  'Accountant, Res Ed Central Operations'])
                        .true?
         expect(result).to be true
@@ -490,15 +482,15 @@ RSpec.describe Rialto::Etl::Transformer do
         # Test 4 people (removed 2 advisees and added one)
         query = client.select(count: { org: :c })
                       .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
-                      .where([:org, RDF.type, Rialto::Etl::Vocabs::FOAF['Person']])
-                      .where([:org, RDF.type, Rialto::Etl::Vocabs::FOAF['Agent']])
+                      .where([:org, RDF.type, RDF::Vocab::FOAF.Person])
+                      .where([:org, RDF.type, RDF::Vocab::FOAF.Agent])
         expect(query.solutions.first[:c].to_i).to eq(4)
 
         # Test label
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150'],
-                                 Rialto::Etl::Vocabs::SKOS['prefLabel'],
+                                 RDF::Vocab::SKOS.prefLabel,
                                  'Billy Edward Chen'])
                        .true?
         expect(result).to be true
@@ -507,13 +499,13 @@ RSpec.describe Rialto::Etl::Transformer do
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['given-name'],
+                                 RDF::Vocab::VCARD['given-name'],
                                  'Billy'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['middle-name'],
+                                 RDF::Vocab::VCARD['additional-name'],
                                  'Edward'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['family-name'],
+                                 RDF::Vocab::VCARD['family-name'],
                                  'Chen'])
                        .true?
         expect(result).to be true
@@ -549,24 +541,24 @@ RSpec.describe Rialto::Etl::Transformer do
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
                                  RDF.type,
-                                 Rialto::Etl::Vocabs::VCARD['Address']])
+                                 RDF::Vocab::VCARD.Address])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['street-address'],
+                                 RDF::Vocab::VCARD['street-address'],
                                  'Tresidder Memorial Union, 3rd Floor, Suite 4, 459 Lagunita Drive'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['locality'],
+                                 RDF::Vocab::VCARD.locality,
                                  'Stanford'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['region'],
+                                 RDF::Vocab::VCARD.region,
                                  'California'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['postal-code'],
+                                 RDF::Vocab::VCARD['postal-code'],
                                  '94305-3073'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['country-name'],
+                                 RDF::Vocab::VCARD['country-name'],
                                  'United States'])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['400150'],
-                                 Rialto::Etl::Vocabs::DCTERMS['spatial'],
+                                 RDF::Vocab::DC.spatial,
                                  RDF::URI.new('http://sws.geonames.org/6252001/')])
                        .true?
         expect(result).to be true
@@ -575,7 +567,7 @@ RSpec.describe Rialto::Etl::Transformer do
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150'],
-                                 Rialto::Etl::Vocabs::VCARD['hasEmail'],
+                                 RDF::Vocab::VCARD.hasEmail,
                                  'billychen1@stanford.edu'])
                        .true?
         expect(result).to be true
@@ -600,7 +592,7 @@ RSpec.describe Rialto::Etl::Transformer do
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_POSITIONS['HMGN_400150'],
-                                 Rialto::Etl::Vocabs::RDFS['label'],
+                                 RDF::Vocab::RDFS.label,
                                  'Senior accountant, Res Ed Central Operations'])
                        .true?
         expect(result).to be true

--- a/spec/configs/wos_to_sparql_statements_spec.rb
+++ b/spec/configs/wos_to_sparql_statements_spec.rb
@@ -77,84 +77,84 @@ RSpec.describe Rialto::Etl::Transformer do
         # specific type
         expect(repository).to have_quad([id,
                                          RDF.type,
-                                         Rialto::Etl::Vocabs::BIBO['Article'],
+                                         RDF::Vocab::BIBO.Article,
                                          graph])
         # general type
         expect(repository).to have_quad([id,
                                          RDF.type,
-                                         Rialto::Etl::Vocabs::BIBO['Document'],
+                                         RDF::Vocab::BIBO.Document,
                                          graph])
         # has Part
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::DCTERMS['isPartOf'],
+                                         RDF::Vocab::DC['isPartOf'],
                                          'EXPERIMENTAL BIOLOGY AND MEDICINE',
                                          graph])
 
         # Created
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::DCTERMS['created'],
+                                         RDF::Vocab::DC['created'],
                                          '2018-02-01',
                                          graph])
 
         # Subject
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::DCTERMS['subject'],
+                                         RDF::Vocab::DC['subject'],
                                          Rialto::Etl::Vocabs::RIALTO_CONCEPTS['d700824f-ae47-4244-885c-7cfc55b240f9'],
                                          graph])
 
         # Title
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::DCTERMS['title'],
+                                         RDF::Vocab::DC['title'],
                                          'Biomarkers: Delivering on the expectation of molecularly driven, quantitative health',
                                          graph])
 
         # Abstract
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::BIBO['abstract'],
+                                         RDF::Vocab::BIBO.abstract,
                                          'Biomarkers are the pillars of precision medicine and are delivering on '\
                                          'expectations of molecular, quantitative health.',
                                          graph])
         # DOI
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::BIBO['doi'],
+                                         RDF::Vocab::BIBO.doi,
                                          '10.1177/1535370217744775',
                                          graph])
         # Identifier
         expect(repository).to has_quads([[id,
-                                          Rialto::Etl::Vocabs::BIBO['identifier'],
+                                          RDF::Vocab::BIBO.identifier,
                                           '1535-3702',
                                           graph],
                                          [id,
-                                          Rialto::Etl::Vocabs::BIBO['identifier'],
+                                          RDF::Vocab::BIBO.identifier,
                                           '1535-3699',
                                           graph],
                                          [id,
-                                          Rialto::Etl::Vocabs::BIBO['identifier'],
+                                          RDF::Vocab::BIBO.identifier,
                                           '10.1177/1535370217744775',
                                           graph],
                                          [id,
-                                          Rialto::Etl::Vocabs::BIBO['identifier'],
+                                          RDF::Vocab::BIBO.identifier,
                                           'MEDLINE:29199461',
                                           graph]])
 
         # Publisher
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::VIVO['publisher'],
+                                         Rialto::Etl::Vocabs::VIVO.publisher,
                                          'SAGE PUBLICATIONS LTD',
                                          graph])
 
         # Authorships
         expect(repository).to has_quads(
           [[id,
-            Rialto::Etl::Vocabs::VIVO['relatedBy'],
+            Rialto::Etl::Vocabs::VIVO.relatedBy,
             Rialto::Etl::Vocabs::RIALTO_CONTEXT_RELATIONSHIPS['WOS:000424386600014_15bf29be-470a-442e-9389-f66aac440a7b'],
             graph],
            [Rialto::Etl::Vocabs::RIALTO_CONTEXT_RELATIONSHIPS['WOS:000424386600014_15bf29be-470a-442e-9389-f66aac440a7b'],
             RDF.type,
-            Rialto::Etl::Vocabs::VIVO['Authorship'],
+            Rialto::Etl::Vocabs::VIVO.Authorship,
             graph],
            [Rialto::Etl::Vocabs::RIALTO_CONTEXT_RELATIONSHIPS['WOS:000424386600014_15bf29be-470a-442e-9389-f66aac440a7b'],
-            Rialto::Etl::Vocabs::VIVO['relates'],
+            Rialto::Etl::Vocabs::VIVO.relates,
             Rialto::Etl::Vocabs::RIALTO_PEOPLE['15bf29be-470a-442e-9389-f66aac440a7b'],
             graph]]
         )
@@ -179,39 +179,39 @@ RSpec.describe Rialto::Etl::Transformer do
         # Authors
         expect(repository).to has_quads(
           [[Rialto::Etl::Vocabs::RIALTO_PEOPLE['15bf29be-470a-442e-9389-f66aac440a7b'],
-            Rialto::Etl::Vocabs::VCARD['hasAddress'],
+            RDF::Vocab::VCARD['hasAddress'],
             Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['15bf29be-470a-442e-9389-f66aac440a7b_WOS:000424386600014'],
             graph],
            [Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['15bf29be-470a-442e-9389-f66aac440a7b_WOS:000424386600014'],
             RDF.type,
-            Rialto::Etl::Vocabs::VCARD['Address'],
+            RDF::Vocab::VCARD['Address'],
             graph],
            [Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['15bf29be-470a-442e-9389-f66aac440a7b_WOS:000424386600014'],
-            Rialto::Etl::Vocabs::VCARD['country-name'],
+            RDF::Vocab::VCARD['country-name'],
             'Peoples R China',
             graph],
            [Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['15bf29be-470a-442e-9389-f66aac440a7b_WOS:000424386600014'],
-            Rialto::Etl::Vocabs::DCTERMS['spatial'],
-            Rialto::Etl::Vocabs::GEONAMES['1814991/'],
+            RDF::Vocab::DC.spatial,
+            Rialto::Etl::Vocabs::SWS_GEONAMES['1814991/'],
             graph]]
         )
 
         expect(repository).to has_quads(
           [[Rialto::Etl::Vocabs::RIALTO_PEOPLE['dc934b74-e554-409b-967b-0d555c44cc2c'],
-            Rialto::Etl::Vocabs::VCARD['hasAddress'],
+            RDF::Vocab::VCARD['hasAddress'],
             Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['dc934b74-e554-409b-967b-0d555c44cc2c_WOS:000424386600014'],
             graph],
            [Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['dc934b74-e554-409b-967b-0d555c44cc2c_WOS:000424386600014'],
             RDF.type,
-            Rialto::Etl::Vocabs::VCARD['Address'],
+            RDF::Vocab::VCARD['Address'],
             graph],
            [Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['dc934b74-e554-409b-967b-0d555c44cc2c_WOS:000424386600014'],
-            Rialto::Etl::Vocabs::VCARD['country-name'],
+            RDF::Vocab::VCARD['country-name'],
             'USA',
             graph],
            [Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['dc934b74-e554-409b-967b-0d555c44cc2c_WOS:000424386600014'],
-            Rialto::Etl::Vocabs::DCTERMS['spatial'],
-            Rialto::Etl::Vocabs::GEONAMES['6252001/'],
+            RDF::Vocab::DC.spatial,
+            Rialto::Etl::Vocabs::SWS_GEONAMES['6252001/'],
             graph]]
         )
 
@@ -265,17 +265,17 @@ RSpec.describe Rialto::Etl::Transformer do
 
       it 'is inserted with subject triples' do
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::DCTERMS['subject'],
+                                         RDF::Vocab::DC['subject'],
                                          Rialto::Etl::Vocabs::RIALTO_CONCEPTS['5a2cd5c7582ed1a1bbcc3a5c62786dca'],
                                          graph])
 
         expect(repository).to have_quad([Rialto::Etl::Vocabs::RIALTO_CONCEPTS['5a2cd5c7582ed1a1bbcc3a5c62786dca'],
                                          RDF.type,
-                                         Rialto::Etl::Vocabs::SKOS['Concept'],
+                                         RDF::Vocab::SKOS['Concept'],
                                          graph])
 
         expect(repository).to have_quad([Rialto::Etl::Vocabs::RIALTO_CONCEPTS['5a2cd5c7582ed1a1bbcc3a5c62786dca'],
-                                         Rialto::Etl::Vocabs::DCTERMS['subject'],
+                                         RDF::Vocab::DC['subject'],
                                          'Research & Experimental Medicine',
                                          graph])
       end
@@ -283,22 +283,22 @@ RSpec.describe Rialto::Etl::Transformer do
       it 'is inserted with people triples' do
         expect(repository).to has_quads([[Rialto::Etl::Vocabs::RIALTO_PEOPLE['5054d6965532201e275067e4766c0ea0'],
                                           RDF.type,
-                                          Rialto::Etl::Vocabs::FOAF['Person'],
+                                          RDF::Vocab::FOAF.Person,
                                           graph],
                                          [Rialto::Etl::Vocabs::RIALTO_PEOPLE['5054d6965532201e275067e4766c0ea0'],
                                           RDF.type,
-                                          Rialto::Etl::Vocabs::FOAF['Agent'],
+                                          RDF::Vocab::FOAF.Agent,
                                           graph]])
       end
 
       it 'is inserted with org triples' do
         expect(repository).to has_quads([[Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['0a4246f93dcdd2c0220c7cde1d23c989'],
                                           RDF.type,
-                                          Rialto::Etl::Vocabs::FOAF['Organization'],
+                                          RDF::Vocab::FOAF.Organization,
                                           graph],
                                          [Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['0a4246f93dcdd2c0220c7cde1d23c989'],
                                           RDF.type,
-                                          Rialto::Etl::Vocabs::FOAF['Agent'],
+                                          RDF::Vocab::FOAF.Agent,
                                           graph]])
       end
     end
@@ -338,84 +338,84 @@ RSpec.describe Rialto::Etl::Transformer do
       it 'updates the publication' do
         # has Part
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::DCTERMS['isPartOf'],
+                                         RDF::Vocab::DC['isPartOf'],
                                          'SPECULATIVE BIOLOGY AND MEDICINE',
                                          graph])
         expect(repository).not_to have_quad([id,
-                                             Rialto::Etl::Vocabs::DCTERMS['isPartOf'],
+                                             RDF::Vocab::DC['isPartOf'],
                                              'EXPERIMENTAL BIOLOGY AND MEDICINE',
                                              graph])
 
         # Created
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::DCTERMS['created'],
+                                         RDF::Vocab::DC['created'],
                                          '2017-02-01',
                                          graph])
         expect(repository).not_to have_quad([id,
-                                             Rialto::Etl::Vocabs::DCTERMS['created'],
+                                             RDF::Vocab::DC['created'],
                                              '2018-02-01',
                                              graph])
 
         # Subject
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::DCTERMS['subject'],
+                                         RDF::Vocab::DC['subject'],
                                          Rialto::Etl::Vocabs::RIALTO_CONCEPTS['d700824f-ae47-4244-885c-7cfc55b240f10'],
                                          graph])
         expect(repository).not_to have_quad([id,
-                                             Rialto::Etl::Vocabs::DCTERMS['subject'],
+                                             RDF::Vocab::DC['subject'],
                                              Rialto::Etl::Vocabs::RIALTO_CONCEPTS['d700824f-ae47-4244-885c-7cfc55b240f9'],
                                              graph])
 
         # Title
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::DCTERMS['title'],
+                                         RDF::Vocab::DC['title'],
                                          'Biomarkers: Delivering some day on the expectation of molecularly driven, '\
                                          'quantitative health',
                                          graph])
         expect(repository).not_to have_quad([id,
-                                             Rialto::Etl::Vocabs::DCTERMS['title'],
+                                             RDF::Vocab::DC['title'],
                                              'Biomarkers: Delivering on the expectation of molecularly driven, quantitative health',
                                              graph])
 
         # Abstract
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::BIBO['abstract'],
+                                         RDF::Vocab::BIBO.abstract,
                                          'Biomarkers are the pillars of precision medicine and may some day deliver on '\
                                          'expectations of molecular, quantitative health.',
                                          graph])
         expect(repository).not_to have_quad([id,
-                                             Rialto::Etl::Vocabs::BIBO['abstract'],
+                                             RDF::Vocab::BIBO.abstract,
                                              'Biomarkers are the pillars of precision medicine and are delivering on '\
                                              'expectations of molecular, quantitative health.',
                                              graph])
         # DOI
         expect(repository).to have_quad([id,
-                                         Rialto::Etl::Vocabs::BIBO['doi'],
+                                         RDF::Vocab::BIBO.doi,
                                          '10.1177/1535370217744774',
                                          graph])
         expect(repository).not_to have_quad([id,
-                                             Rialto::Etl::Vocabs::BIBO['doi'],
+                                             RDF::Vocab::BIBO.doi,
                                              '10.1177/1535370217744775',
                                              graph])
         # Identifier
         expect(repository).to has_quads([[id,
-                                          Rialto::Etl::Vocabs::BIBO['identifier'],
+                                          RDF::Vocab::BIBO.identifier,
                                           '1535-3670',
                                           graph],
                                          [id,
-                                          Rialto::Etl::Vocabs::BIBO['identifier'],
+                                          RDF::Vocab::BIBO.identifier,
                                           '10.1177/1535370217744774',
                                           graph],
                                          [id,
-                                          Rialto::Etl::Vocabs::BIBO['identifier'],
+                                          RDF::Vocab::BIBO.identifier,
                                           'MEDLINE:29199461',
                                           graph]])
         expect(repository).not_to has_quads([[id,
-                                              Rialto::Etl::Vocabs::BIBO['identifier'],
+                                              RDF::Vocab::BIBO.identifier,
                                               '1535-3702',
                                               graph],
                                              [id,
-                                              Rialto::Etl::Vocabs::BIBO['identifier'],
+                                              RDF::Vocab::BIBO.identifier,
                                               '1535-3699']])
 
         # Publisher

--- a/spec/transformers/organizations_spec.rb
+++ b/spec/transformers/organizations_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Rialto::Etl::Transformers::Organizations do
     it 'returns the organization' do
       expect(org).to eq(
         '@id' => Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['0a4246f93dcdd2c0220c7cde1d23c989'],
-        '@type' => [Rialto::Etl::Vocabs::FOAF['Agent'], Rialto::Etl::Vocabs::FOAF['Organization']],
-        Rialto::Etl::Vocabs::SKOS['prefLabel'].to_s => 'Stanford University',
-        Rialto::Etl::Vocabs::RDFS['label'].to_s => 'Stanford University'
+        '@type' => [RDF::Vocab::FOAF.Agent, RDF::Vocab::FOAF.Organization],
+        RDF::Vocab::SKOS.prefLabel.to_s => 'Stanford University',
+        RDF::RDFS.label.to_s => 'Stanford University'
       )
     end
   end
@@ -46,9 +46,9 @@ RSpec.describe Rialto::Etl::Transformers::Organizations do
       it 'returns unresolved organization' do
         expect(org).to eq(
           '@id' => Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['0a4246f93dcdd2c0220c7cde1d23c989'],
-          '@type' => [Rialto::Etl::Vocabs::FOAF['Agent'], Rialto::Etl::Vocabs::FOAF['Organization']],
-          Rialto::Etl::Vocabs::SKOS['prefLabel'].to_s => 'Stanford University',
-          Rialto::Etl::Vocabs::RDFS['label'].to_s => 'Stanford University'
+          '@type' => [RDF::Vocab::FOAF.Agent, RDF::Vocab::FOAF.Organization],
+          RDF::Vocab::SKOS.prefLabel.to_s => 'Stanford University',
+          RDF::RDFS.label.to_s => 'Stanford University'
         )
       end
     end

--- a/spec/transformers/people_spec.rb
+++ b/spec/transformers/people_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe Rialto::Etl::Transformers::People do
           },
           '#organization' => {
             '@id' => Rialto::Etl::Vocabs::RIALTO_ORGANIZATIONS['0a4246f93dcdd2c0220c7cde1d23c989'],
-            '@type' => [Rialto::Etl::Vocabs::FOAF['Agent'], Rialto::Etl::Vocabs::FOAF['Organization']],
-            Rialto::Etl::Vocabs::SKOS['prefLabel'].to_s => 'Stanford University',
-            Rialto::Etl::Vocabs::RDFS['label'].to_s => 'Stanford University'
+            '@type' => [RDF::Vocab::FOAF.Agent, RDF::Vocab::FOAF.Organization],
+            RDF::Vocab::SKOS.prefLabel.to_s => 'Stanford University',
+            RDF::RDFS.label.to_s => 'Stanford University'
           }
         )
       end
@@ -154,19 +154,19 @@ RSpec.describe Rialto::Etl::Transformers::People do
       it 'returns address vcard hash' do
         expect(vcard).to eq(
           '@id' => Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['123'],
-          '@type' => Rialto::Etl::Vocabs::VCARD['Address'],
-          "!#{Rialto::Etl::Vocabs::VCARD['street-address']}" => true,
-          "!#{Rialto::Etl::Vocabs::VCARD['locality']}" => true,
-          "!#{Rialto::Etl::Vocabs::VCARD['region']}" => true,
-          "!#{Rialto::Etl::Vocabs::VCARD['country-name']}" => true,
-          "!#{Rialto::Etl::Vocabs::VCARD['postal-code']}" => true,
-          "!#{Rialto::Etl::Vocabs::DCTERMS['spatial']}" => true,
-          Rialto::Etl::Vocabs::VCARD['street-address'].to_s => '557 Escondido Mall',
-          Rialto::Etl::Vocabs::VCARD['locality'].to_s => 'Stanford',
-          Rialto::Etl::Vocabs::VCARD['region'].to_s => 'CA',
-          Rialto::Etl::Vocabs::VCARD['postal-code'].to_s => '94305',
-          Rialto::Etl::Vocabs::VCARD['country-name'].to_s => 'USA',
-          Rialto::Etl::Vocabs::DCTERMS['spatial'].to_s => Rialto::Etl::Vocabs::GEONAMES['6252001/']
+          '@type' => RDF::Vocab::VCARD['Address'],
+          "!#{RDF::Vocab::VCARD['street-address']}" => true,
+          "!#{RDF::Vocab::VCARD['locality']}" => true,
+          "!#{RDF::Vocab::VCARD['region']}" => true,
+          "!#{RDF::Vocab::VCARD['country-name']}" => true,
+          "!#{RDF::Vocab::VCARD['postal-code']}" => true,
+          "!#{RDF::Vocab::DC.spatial}" => true,
+          RDF::Vocab::VCARD['street-address'].to_s => '557 Escondido Mall',
+          RDF::Vocab::VCARD['locality'].to_s => 'Stanford',
+          RDF::Vocab::VCARD['region'].to_s => 'CA',
+          RDF::Vocab::VCARD['postal-code'].to_s => '94305',
+          RDF::Vocab::VCARD['country-name'].to_s => 'USA',
+          RDF::Vocab::DC.spatial.to_s => Rialto::Etl::Vocabs::SWS_GEONAMES['6252001/']
         )
       end
       context 'when country only is provided' do
@@ -183,15 +183,15 @@ RSpec.describe Rialto::Etl::Transformers::People do
         it 'returns address vcard hash' do
           expect(vcard).to eq(
             '@id' => Rialto::Etl::Vocabs::RIALTO_CONTEXT_ADDRESSES['123'],
-            '@type' => Rialto::Etl::Vocabs::VCARD['Address'],
-            "!#{Rialto::Etl::Vocabs::VCARD['street-address']}" => true,
-            "!#{Rialto::Etl::Vocabs::VCARD['locality']}" => true,
-            "!#{Rialto::Etl::Vocabs::VCARD['region']}" => true,
-            "!#{Rialto::Etl::Vocabs::VCARD['country-name']}" => true,
-            "!#{Rialto::Etl::Vocabs::VCARD['postal-code']}" => true,
-            "!#{Rialto::Etl::Vocabs::DCTERMS['spatial']}" => true,
-            Rialto::Etl::Vocabs::VCARD['country-name'].to_s => 'Wales',
-            Rialto::Etl::Vocabs::DCTERMS['spatial'].to_s => Rialto::Etl::Vocabs::GEONAMES['2635167/']
+            '@type' => RDF::Vocab::VCARD['Address'],
+            "!#{RDF::Vocab::VCARD['street-address']}" => true,
+            "!#{RDF::Vocab::VCARD['locality']}" => true,
+            "!#{RDF::Vocab::VCARD['region']}" => true,
+            "!#{RDF::Vocab::VCARD['country-name']}" => true,
+            "!#{RDF::Vocab::VCARD['postal-code']}" => true,
+            "!#{RDF::Vocab::DC.spatial}" => true,
+            RDF::Vocab::VCARD['country-name'].to_s => 'Wales',
+            RDF::Vocab::DC.spatial.to_s => Rialto::Etl::Vocabs::SWS_GEONAMES['2635167/']
           )
         end
       end
@@ -214,13 +214,13 @@ RSpec.describe Rialto::Etl::Transformers::People do
       it 'returns the correct fullname' do
         expect(vcard).to eq(
           '@id' => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['123'],
-          '@type' => Rialto::Etl::Vocabs::VCARD['Name'],
-          "!#{Rialto::Etl::Vocabs::VCARD['given-name']}" => true,
-          "!#{Rialto::Etl::Vocabs::VCARD['middle-name']}" => true,
-          "!#{Rialto::Etl::Vocabs::VCARD['family-name']}" => true,
-          Rialto::Etl::Vocabs::VCARD['given-name'].to_s => 'Justin',
-          Rialto::Etl::Vocabs::VCARD['middle-name'].to_s => 'Cunningham',
-          Rialto::Etl::Vocabs::VCARD['family-name'].to_s => 'Littman'
+          '@type' => RDF::Vocab::VCARD['Name'],
+          "!#{RDF::Vocab::VCARD['given-name']}" => true,
+          "!#{RDF::Vocab::VCARD['additional-name']}" => true,
+          "!#{RDF::Vocab::VCARD['family-name']}" => true,
+          RDF::Vocab::VCARD['given-name'].to_s => 'Justin',
+          RDF::Vocab::VCARD['additional-name'].to_s => 'Cunningham',
+          RDF::Vocab::VCARD['family-name'].to_s => 'Littman'
         )
       end
       context 'when middle name and id not provided' do
@@ -231,12 +231,12 @@ RSpec.describe Rialto::Etl::Transformers::People do
         it 'returns the correct fullname' do
           expect(vcard).to eq(
             '@id' => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['ed1aa059391f675499eda6172ddc29f4'],
-            '@type' => Rialto::Etl::Vocabs::VCARD['Name'],
-            "!#{Rialto::Etl::Vocabs::VCARD['given-name']}" => true,
-            "!#{Rialto::Etl::Vocabs::VCARD['middle-name']}" => true,
-            "!#{Rialto::Etl::Vocabs::VCARD['family-name']}" => true,
-            Rialto::Etl::Vocabs::VCARD['given-name'].to_s => 'Justin',
-            Rialto::Etl::Vocabs::VCARD['family-name'].to_s => 'Littman'
+            '@type' => RDF::Vocab::VCARD['Name'],
+            "!#{RDF::Vocab::VCARD['given-name']}" => true,
+            "!#{RDF::Vocab::VCARD['additional-name']}" => true,
+            "!#{RDF::Vocab::VCARD['family-name']}" => true,
+            RDF::Vocab::VCARD['given-name'].to_s => 'Justin',
+            RDF::Vocab::VCARD['family-name'].to_s => 'Littman'
           )
         end
       end
@@ -285,18 +285,18 @@ RSpec.describe Rialto::Etl::Transformers::People do
     it 'returns the person' do
       expect(person).to eq(
         '@id' => Rialto::Etl::Vocabs::RIALTO_PEOPLE['123'],
-        '@type' => [Rialto::Etl::Vocabs::FOAF['Agent'], Rialto::Etl::Vocabs::FOAF['Person']],
-        Rialto::Etl::Vocabs::SKOS['prefLabel'].to_s => 'Justin Cunningham Littman',
-        Rialto::Etl::Vocabs::RDFS['label'].to_s => 'Justin Cunningham Littman',
-        Rialto::Etl::Vocabs::VCARD['hasName'].to_s => {
+        '@type' => [RDF::Vocab::FOAF.Agent, RDF::Vocab::FOAF.Person],
+        RDF::Vocab::SKOS.prefLabel.to_s => 'Justin Cunningham Littman',
+        RDF::Vocab::RDFS.label.to_s => 'Justin Cunningham Littman',
+        RDF::Vocab::VCARD['hasName'].to_s => {
           '@id' => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['123'],
-          '@type' => Rialto::Etl::Vocabs::VCARD['Name'],
-          "!#{Rialto::Etl::Vocabs::VCARD['given-name']}" => true,
-          "!#{Rialto::Etl::Vocabs::VCARD['middle-name']}" => true,
-          "!#{Rialto::Etl::Vocabs::VCARD['family-name']}" => true,
-          Rialto::Etl::Vocabs::VCARD['given-name'].to_s => 'Justin',
-          Rialto::Etl::Vocabs::VCARD['middle-name'].to_s => 'Cunningham',
-          Rialto::Etl::Vocabs::VCARD['family-name'].to_s => 'Littman'
+          '@type' => RDF::Vocab::VCARD['Name'],
+          "!#{RDF::Vocab::VCARD['given-name']}" => true,
+          "!#{RDF::Vocab::VCARD['additional-name']}" => true,
+          "!#{RDF::Vocab::VCARD['family-name']}" => true,
+          RDF::Vocab::VCARD['given-name'].to_s => 'Justin',
+          RDF::Vocab::VCARD['additional-name'].to_s => 'Cunningham',
+          RDF::Vocab::VCARD['family-name'].to_s => 'Littman'
 
         }
       )
@@ -338,17 +338,17 @@ RSpec.describe Rialto::Etl::Transformers::People do
       it 'returns unresolved person' do
         expect(person).to eq(
           '@id' => Rialto::Etl::Vocabs::RIALTO_PEOPLE['ed1aa059391f675499eda6172ddc29f4'],
-          '@type' => [Rialto::Etl::Vocabs::FOAF['Agent'], Rialto::Etl::Vocabs::FOAF['Person']],
-          Rialto::Etl::Vocabs::SKOS['prefLabel'].to_s => 'Justin Littman',
-          Rialto::Etl::Vocabs::RDFS['label'].to_s => 'Justin Littman',
-          Rialto::Etl::Vocabs::VCARD['hasName'].to_s => {
+          '@type' => [RDF::Vocab::FOAF.Agent, RDF::Vocab::FOAF.Person],
+          RDF::Vocab::SKOS.prefLabel.to_s => 'Justin Littman',
+          RDF::RDFS.label.to_s => 'Justin Littman',
+          RDF::Vocab::VCARD.hasName.to_s => {
             '@id' => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['ed1aa059391f675499eda6172ddc29f4'],
-            '@type' => Rialto::Etl::Vocabs::VCARD['Name'],
-            "!#{Rialto::Etl::Vocabs::VCARD['given-name']}" => true,
-            "!#{Rialto::Etl::Vocabs::VCARD['middle-name']}" => true,
-            "!#{Rialto::Etl::Vocabs::VCARD['family-name']}" => true,
-            Rialto::Etl::Vocabs::VCARD['given-name'].to_s => 'Justin',
-            Rialto::Etl::Vocabs::VCARD['family-name'].to_s => 'Littman'
+            '@type' => RDF::Vocab::VCARD.Name,
+            "!#{RDF::Vocab::VCARD['given-name']}" => true,
+            "!#{RDF::Vocab::VCARD['additional-name']}" => true,
+            "!#{RDF::Vocab::VCARD['family-name']}" => true,
+            RDF::Vocab::VCARD['given-name'].to_s => 'Justin',
+            RDF::Vocab::VCARD['family-name'].to_s => 'Littman'
           }
         )
       end

--- a/spec/writers/sparql_statement_writer_spec.rb
+++ b/spec/writers/sparql_statement_writer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
 
   describe 'simple inserts and deletes' do
     before do
-      graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'], Rialto::Etl::Vocabs::SKOS['prefLabel'], 'Justin']
+      graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'], RDF::Vocab::SKOS.prefLabel, 'Justin']
       execute_sparql!(writer.graph_to_insert(graph, Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH))
     end
 
@@ -41,8 +41,8 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
     let(:first_statements) do
       writer.add_type_assertions(Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'],
                                  [
-                                   Rialto::Etl::Vocabs::FOAF['Agent'],
-                                   Rialto::Etl::Vocabs::FOAF['Organization']
+                                   RDF::Vocab::FOAF.Agent,
+                                   RDF::Vocab::FOAF.Organization
                                  ],
                                  Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
     end
@@ -50,15 +50,15 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
     let(:second_statements) do
       writer.add_type_assertions(Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'],
                                  [
-                                   Rialto::Etl::Vocabs::FOAF['Agent'],
-                                   Rialto::Etl::Vocabs::FOAF['Person']
+                                   RDF::Vocab::FOAF.Agent,
+                                   RDF::Vocab::FOAF.Person
                                  ],
                                  Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
     end
 
     before do
-      graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'], RDF.type, Rialto::Etl::Vocabs::FOAF['Agent']]
-      graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'], RDF.type, Rialto::Etl::Vocabs::FOAF['Person']]
+      graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'], RDF.type, RDF::Vocab::FOAF.Agent]
+      graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'], RDF.type, RDF::Vocab::FOAF.Person]
       execute_sparql!(first_statements)
       execute_sparql!(second_statements)
     end
@@ -71,14 +71,14 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
       {
         '@id' => Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'].to_s,
         '@graph' => Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH.to_s,
-        '@type' => [Rialto::Etl::Vocabs::FOAF['person'], Rialto::Etl::Vocabs::VIVO['Librarian']],
+        '@type' => [RDF::Vocab::FOAF.Person, Rialto::Etl::Vocabs::VIVO['Librarian']],
         Rialto::Etl::Vocabs::VIVO['overview'].to_s => 'Justin Littman is a software developer and librarian.',
-        Rialto::Etl::Vocabs::VCARD['hasEmail'].to_s => 'jlittypo@example.org',
+        RDF::Vocab::VCARD['hasEmail'].to_s => 'jlittypo@example.org',
         '#advisee' => {
           '@id' => Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'].to_s,
           '@graph' => Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH.to_s,
-          '@type' => [Rialto::Etl::Vocabs::FOAF['Person']],
-          Rialto::Etl::Vocabs::VCARD['hasName'].to_s => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['188882']
+          '@type' => [RDF::Vocab::FOAF.Person],
+          RDF::Vocab::VCARD['hasName'].to_s => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['188882']
         }
       }
     end
@@ -87,9 +87,9 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
       {
         '@id' => Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'].to_s,
         '@graph' => Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH.to_s,
-        '@type' => [Rialto::Etl::Vocabs::FOAF['person'], Rialto::Etl::Vocabs::VIVO['Librarian']],
-        "!#{Rialto::Etl::Vocabs::VCARD['hasEmail']}" => true,
-        Rialto::Etl::Vocabs::VCARD['hasEmail'].to_s => 'jlit@example.org'
+        '@type' => [RDF::Vocab::FOAF.Person, Rialto::Etl::Vocabs::VIVO['Librarian']],
+        "!#{RDF::Vocab::VCARD['hasEmail']}" => true,
+        RDF::Vocab::VCARD['hasEmail'].to_s => 'jlit@example.org'
       }
     end
 
@@ -98,17 +98,17 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
     let(:second_statements) { writer.serialize_hash(second_hash) }
 
     before do
-      graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'], RDF.type, Rialto::Etl::Vocabs::FOAF['person']]
+      graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'], RDF.type, RDF::Vocab::FOAF.Person]
       graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'], RDF.type, Rialto::Etl::Vocabs::VIVO['Librarian']]
       graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'],
                 Rialto::Etl::Vocabs::VIVO['overview'],
                 'Justin Littman is a software developer and librarian.']
       graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'],
-                Rialto::Etl::Vocabs::VCARD['hasEmail'],
+                RDF::Vocab::VCARD['hasEmail'],
                 'jlit@example.org']
-      graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'], RDF.type, Rialto::Etl::Vocabs::FOAF['Person']]
+      graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'], RDF.type, RDF::Vocab::FOAF.Person]
       graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'],
-                Rialto::Etl::Vocabs::VCARD['hasName'],
+                RDF::Vocab::VCARD['hasName'],
                 Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['188882']]
 
       execute_sparql!(first_statements)


### PR DESCRIPTION
So that we only use terms that exist in the vocabularies.

This change required vcard:middle-name to become vcard:additional-name