### PR TITLE
Handle errors in publications CLI

### DIFF
--- a/lib/rialto/etl/cli/grants.rb
+++ b/lib/rialto/etl/cli/grants.rb
@@ -26,17 +26,19 @@ module Rialto
         option :batch_size,
                required: false,
                default: 3,
+               type: :numeric,
                banner: 'BATCH_SIZE',
                desc: 'Size of batch for parallel processing',
                aliases: '-s'
         option :force,
                required: false,
                default: false,
+               type: :boolean,
                banner: 'FORCE',
                desc: 'Overwrite files that already exist',
                aliases: '-f'
 
-        desc 'Load', 'Load all grants for all researchers in the file'
+        desc 'Load', 'Load all grants for all researchers in the JSON file'
         # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/AbcSize
         def load

--- a/lib/rialto/etl/service_client/entity_resolver.rb
+++ b/lib/rialto/etl/service_client/entity_resolver.rb
@@ -25,8 +25,10 @@ module Rialto
           @conn = connection
         end
 
+        # rubocop:disable Metrics/MethodLength
         def resolve(type, params)
-          resp = conn.get(type, params)
+          path = "#{type}?#{URI.encode_www_form(params)}"
+          resp = conn.get(path)
           case resp.status
           when 200..299
             RDF::URI.new(resp.body)
@@ -35,7 +37,10 @@ module Rialto
           else
             raise "Entity resolver returned #{resp.status} for #{type} type and #{params} params."
           end
+        rescue StandardError => exception
+          warn "Error resolving with path #{path}: #{exception.message}"
         end
+        # rubocop:enable Metrics/MethodLength
 
         def connection
           ConnectionFactory.build(uri: ::Settings.entity_resolver.url, headers: connection_headers)

--- a/lib/rialto/etl/transformer.rb
+++ b/lib/rialto/etl/transformer.rb
@@ -9,14 +9,15 @@ module Rialto
     class Transformer
       include Rialto::Etl::Logging
 
-      attr_reader :input_stream, :config_file_path
+      attr_reader :input_stream, :config_file_path, :output_file_path
 
       # Initialize a new instance of the transformer
       #
       # @param input [String] valid file path
-      def initialize(input_stream:, config_file_path:)
+      def initialize(input_stream:, config_file_path:, output_file_path: nil)
         @input_stream = input_stream
         @config_file_path = config_file_path
+        @output_file_path = output_file_path
       end
 
       # Transform a stream into a new representation, using Traject
@@ -30,6 +31,7 @@ module Rialto
         @transformer ||= Traject::Indexer.new.tap do |indexer|
           indexer.load_config_file(config_file_path)
           indexer.logger = logger
+          indexer.settings['output_file'] = output_file_path unless output_file_path.nil?
         end
       end
     end

--- a/spec/extractors/web_of_science_spec.rb
+++ b/spec/extractors/web_of_science_spec.rb
@@ -8,27 +8,52 @@ RSpec.describe Rialto::Etl::Extractors::WebOfScience do
 
     context 'when client raises an exception' do
       let(:error_message) { 'Uh oh!' }
+      let(:path) { 'organization?whatever+university' }
+      let(:client) { instance_double(Rialto::Etl::ServiceClient::WebOfScienceClient, path: path) }
 
       before do
-        stub_request(:get, 'https://api.clarivate.com/api/wos?count=100&databaseId=WOS&firstRecord=1&usrQuery=AU=,%20AND%20OG=Stanford%20University')
+        stub_request(:get, 'https://api.clarivate.com/api/wos?count=100&databaseId=WOS&firstRecord=1&usrQuery=AU=Abel,Tom%20AND%20OG=Stanford%20University')
           .to_return(status: 200, body: '{"Data":{"Records": { "records": {"REC": ["one", "two"]}}},'\
             '"QueryResult": {"RecordsFound": 3}}')
 
-        allow(extractor).to receive(:client).and_raise(error_message)
+        allow(extractor).to receive(:client).and_return(client)
+        allow(client).to receive(:request).and_raise(error_message)
       end
 
       it 'prints out the exception' do
-        expect { extractor.each {} }.to output("Error: #{error_message}\n").to_stderr
+        expect { extractor.each {} }.to output("Error fetching #{path}: #{error_message}\n").to_stderr
       end
     end
 
+    # rubocop:disable RSpec/VerifiedDoubles
+    context 'when connection is throttled' do
+      let(:client) { double('client', request: request, path: 'foo') }
+      let(:request) { double('request', success?: false, status: 429) }
+
+      before do
+        allow(extractor).to receive(:client).and_return(client)
+        allow(extractor).to receive(:sleep)
+        allow(extractor).to receive(:more).and_return(true, false)
+      end
+
+      it 'retries three times' do
+        expect { extractor.each {} }.to output(
+          "retrying connection to WebOfScience because connection is throttled. Sleeping for 1 second(s)...\n" \
+            "retrying connection to WebOfScience because connection is throttled. Sleeping for 2 second(s)...\n" \
+            "retrying connection to WebOfScience because connection is throttled. Sleeping for 3 second(s)...\n"
+        ).to_stdout
+        expect(extractor).to have_received(:sleep).exactly(3).times
+      end
+    end
+    # rubocop:enable RSpec/VerifiedDoubles
+
     context 'when there is more than one page of results' do
       before do
-        stub_request(:get, 'https://api.clarivate.com/api/wos?count=2&databaseId=WOS&firstRecord=1&usrQuery=AU=,%20AND%20OG=Stanford%20University')
+        stub_request(:get, 'https://api.clarivate.com/api/wos?count=2&databaseId=WOS&firstRecord=1&usrQuery=AU=Abel,Tom%20AND%20OG=Stanford%20University')
           .to_return(status: 200, body: '{"Data":{"Records": { "records": {"REC": ["one", "two"]}}},'\
             '"QueryResult": {"RecordsFound": 3}}')
 
-        stub_request(:get, 'https://api.clarivate.com/api/wos?count=2&databaseId=WOS&firstRecord=3&usrQuery=AU=,%20AND%20OG=Stanford%20University')
+        stub_request(:get, 'https://api.clarivate.com/api/wos?count=2&databaseId=WOS&firstRecord=3&usrQuery=AU=Abel,Tom%20AND%20OG=Stanford%20University')
           .to_return(status: 200, body: '{"Data":{"Records": { "records": {"REC": ["three"]}}},'\
             '"QueryResult": {"RecordsFound": 3}}')
 
@@ -47,7 +72,7 @@ RSpec.describe Rialto::Etl::Extractors::WebOfScience do
 
     context 'when there is only one result' do
       before do
-        stub_request(:get, 'https://api.clarivate.com/api/wos?count=2&databaseId=WOS&firstRecord=1&usrQuery=AU=,%20AND%20OG=Stanford%20University')
+        stub_request(:get, 'https://api.clarivate.com/api/wos?count=2&databaseId=WOS&firstRecord=1&usrQuery=AU=Abel,Tom%20AND%20OG=Stanford%20University')
           .to_return(status: 200, body: '{"Data":{"Records": { "records": {"REC": "one"}}},'\
             '"QueryResult": {"RecordsFound": 1}}')
 

--- a/spec/service_client/entity_resolver_spec.rb
+++ b/spec/service_client/entity_resolver_spec.rb
@@ -21,19 +21,21 @@ RSpec.describe Rialto::Etl::ServiceClient::EntityResolver do
         stub_request(:get, 'http://127.0.0.1:3001/person?full_name=Wilson,%20Jennifer%20L.&orcid_id=0000-0002-2328-2018')
           .to_return(status: 404, body: '')
       end
-      it 'gets the URI' do
+      it 'returns nil' do
         expect(resolve).to be_nil
       end
     end
 
+    # rubocop:disable Metrics/LineLength
     context 'when resolver behaves unexpectedly' do
       before do
         stub_request(:get, 'http://127.0.0.1:3001/person?full_name=Wilson,%20Jennifer%20L.&orcid_id=0000-0002-2328-2018')
           .to_return(status: 500, body: '')
       end
-      it 'gets the URI' do
-        expect { resolve }.to raise_error(RuntimeError, /Entity resolver returned 500 for person type and/)
+      it 'prints a warning' do
+        expect { resolve }.to output('Error resolving with path person?orcid_id=0000-0002-2328-2018&full_name=Wilson%2C+Jennifer+L.: Entity resolver returned 500 for person type and {"orcid_id"=>"0000-0002-2328-2018", "full_name"=>"Wilson, Jennifer L."} params.' + "\n").to_stderr
       end
     end
+    # rubocop:enable Metrics/LineLength
   end
 end


### PR DESCRIPTION
Fixes #192

This branch contains a number of changes intended to make harvesting and transforming publications more robust and less brittle. It also includes work to bring both the grants CLI and the publications CLI into alignment, increasing internal consistency in RIALTO-ETL. Specific changes include:

* Add types to options (where missing) in grants CLI
* List CLI options in a consistent order using the same args for each option
* Rename `skip_existing` option to `force` with `-f` as an alias
* Use global `options` object in CLI instead of passing them around as args
* Halt extract/transform/load flow in publications CLI if extract or transform files do not exist
* Use CLI classes in publications CLI instead of system calls
* Add handling for throttled connections in WoS extractor, backing off and waiting when encountering these
* Retry up to three times when connection is throttled
* Handle firstname and lastname args in WoS extractor consistently as symbols
* Encode outgoing GET params when hitting the entity resolver
* Allow injection of output file path into `Transformer` so code is less reliant on stdout/CLI invocation