### PR TITLE
Set entity resolver url in spec

### DIFF
--- a/spec/service_client/entity_resolver_spec.rb
+++ b/spec/service_client/entity_resolver_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Rialto::Etl::ServiceClient::EntityResolver do
+  before do
+    Settings.entity_resolver.url = 'http://127.0.0.1:3001'
+    # Makes sure Entity Resolver is using above settings.
+    described_class.instance.initialize_connection
+  end
+
   describe '.resolve' do
     subject(:resolve) do
       described_class.resolve('person', 'orcid_id' => '0000-0002-2328-2018', 'full_name' => 'Wilson, Jennifer L.')


### PR DESCRIPTION
The entity resolver defaults to the configuration in `settings.yml` and `settings.local.yml`. If the entity resolver is set to a different port, this test will fail.

Other tests similarly force the configuration of the port.