### PR TITLE
Require rdf library in entity resolver

### DIFF
--- a/lib/rialto/etl/service_client/entity_resolver.rb
+++ b/lib/rialto/etl/service_client/entity_resolver.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rdf'
 require 'singleton'
 
 module Rialto


### PR DESCRIPTION
Else, successful resolutions barf when encountering `RDF::URI.new(resp.body)` because of an uninitialized constant. I did not add a test for this behavior because RDF.rb is already required in the test suite and it did not seem worth trying to e.g. unrequire it to create a failure.