### PR TITLE
Redesign WoS extraction

### DIFF
--- a/lib/rialto/etl/extractors/web_of_science.rb
+++ b/lib/rialto/etl/extractors/web_of_science.rb
@@ -7,8 +7,9 @@ module Rialto
     module Extractors
       # Web of Science JSON API client
       class WebOfScience
-        # Instead of a bare `raise`, raise a custom error so it can be caught reliably
-        class ThrottledConnectionError < StandardError; end
+        DEFAULT_INSTITUTION = 'Stanford University'
+
+        attr_reader :client
 
         # @param [Hash] options
         # @option options [String] :client a preconfigured client.  May be used for testing, all other
@@ -18,64 +19,23 @@ module Rialto
         # @option options [String] :institution ('Stanford University') The institution to search for
         def initialize(options)
           @client = options.fetch(:client) { build_client(options) }
-          @more = true
-          @page = options[:start_page] || 1
         end
 
-        # rubocop:disable Metrics/MethodLength
-        # Hit an API endpoint and return the results
-        def each(&_block)
+        # Use the client to iterate over records and yield them as JSON
+        def each
           return to_enum(:each) unless block_given?
-          while more
-            begin
-              retries ||= 0
-              # Retrieve a page of results
-              records = fetch_results_for_page(page)
-            rescue ThrottledConnectionError
-              retries += 1
-              puts "retrying connection to WebOfScience because connection is throttled. Sleeping for #{retries} second(s)..."
-              sleep retries
-              retry if retries < 3
-            rescue StandardError => exception
-              warn "Error fetching #{client.path(page: page)}: #{exception.message}"
-              return
-            end
-            # Yield the block for each result on the page
-            Array.wrap(records).each do |val|
-              yield val.to_json
-            end
+          client.each do |record|
+            yield record.to_json
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         private
-
-        attr_accessor :more, :page
-        attr_reader :client
 
         def build_client(options)
           ServiceClient::WebOfScienceClient.new(firstname: options[:firstname],
                                                 lastname: options[:lastname],
-                                                institution: options.fetch('institution', 'Stanford University'))
+                                                institution: options.fetch(:institution, DEFAULT_INSTITUTION))
         end
-
-        # rubocop:disable Metrics/AbcSize
-        def fetch_results_for_page(page)
-          result = client.request(page: page)
-          unless result.success?
-            raise result.status == 429 ? ThrottledConnectionError : result.body
-          end
-          json = JSON.parse(result.body)
-          found = json.fetch('QueryResult').fetch('RecordsFound')
-          self.more = client.last_record(page: page) < found
-
-          # web of science returns an empty string of records in this case.
-          return [] if found.zero?
-
-          self.page = page + 1 if more
-          Array.wrap(json.fetch('Data').fetch('Records').fetch('records').fetch('REC'))
-        end
-        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/spec/extractors/web_of_science_spec.rb
+++ b/spec/extractors/web_of_science_spec.rb
@@ -1,90 +1,72 @@
 # frozen_string_literal: true
 
 RSpec.describe Rialto::Etl::Extractors::WebOfScience do
+  subject(:extractor) { described_class.new(options) }
+
+  let(:options) { {} }
+
+  describe '#initialize' do
+    context 'when given a client' do
+      let(:client) { double }
+      let(:options) { { client: client } }
+
+      it 'uses the supplied client' do
+        expect(extractor.client).to eq client
+      end
+    end
+
+    context 'when not given a client' do
+      before do
+        stub_request(:get, 'https://api.clarivate.com/api/wos' \
+          '?count=1&databaseId=WOS&firstRecord=1&usrQuery=AU=%22,%22%20AND%20OG=Stanford%20University')
+          .to_return(status: 200, body: '{}', headers: {})
+      end
+
+      it 'builds a client' do
+        expect(extractor.client).to be_an_instance_of(Rialto::Etl::ServiceClient::WebOfScienceClient)
+      end
+    end
+
+    context 'when given an institution' do
+      let(:institution) { 'Foo University' }
+      let(:options) { { institution: institution } }
+
+      before do
+        stub_request(:get, 'https://api.clarivate.com/api/wos' \
+          '?count=1&databaseId=WOS&firstRecord=1&usrQuery=AU=%22,%22%20AND%20OG=Foo%20University')
+          .to_return(status: 200, body: '{}', headers: {})
+      end
+
+      it 'passes the value to the client' do
+        expect(extractor.client.institution).to eq institution
+      end
+    end
+
+    context 'when not given an institution' do
+      before do
+        stub_request(:get, 'https://api.clarivate.com/api/wos' \
+          '?count=1&databaseId=WOS&firstRecord=1&usrQuery=AU=%22,%22%20AND%20OG=Stanford%20University')
+          .to_return(status: 200, body: '{}', headers: {})
+      end
+
+      it 'defaults to "Stanford University"' do
+        expect(extractor.client.institution).to eq described_class::DEFAULT_INSTITUTION
+      end
+    end
+  end
+
   describe '#each' do
-    subject(:extractor) { described_class.new(options) }
-
-    let(:options) { { firstname: 'Tom', lastname: 'Abel' } }
-
-    context 'when client raises an exception' do
-      let(:error_message) { 'Uh oh!' }
-      let(:path) { 'organization?whatever+university' }
-      let(:client) { instance_double(Rialto::Etl::ServiceClient::WebOfScienceClient, path: path) }
-
-      before do
-        stub_request(:get, 'https://api.clarivate.com/api/wos?count=100&databaseId=WOS&firstRecord=1&usrQuery=AU=Abel,Tom%20AND%20OG=Stanford%20University')
-          .to_return(status: 200, body: '{"Data":{"Records": { "records": {"REC": ["one", "two"]}}},'\
-            '"QueryResult": {"RecordsFound": 3}}')
-
-        allow(extractor).to receive(:client).and_return(client)
-        allow(client).to receive(:request).and_raise(error_message)
-      end
-
-      it 'prints out the exception' do
-        expect { extractor.each {} }.to output("Error fetching #{path}: #{error_message}\n").to_stderr
-      end
+    let(:client) do
+      [
+        { key1: 'value1' },
+        { key2: 'value2' }
+      ]
     end
+    let(:options) { { client: client } }
 
-    # rubocop:disable RSpec/VerifiedDoubles
-    context 'when connection is throttled' do
-      let(:client) { double('client', request: request, path: 'foo') }
-      let(:request) { double('request', success?: false, status: 429) }
-
-      before do
-        allow(extractor).to receive(:client).and_return(client)
-        allow(extractor).to receive(:sleep)
-        allow(extractor).to receive(:more).and_return(true, false)
-      end
-
-      it 'retries three times' do
-        expect { extractor.each {} }.to output(
-          "retrying connection to WebOfScience because connection is throttled. Sleeping for 1 second(s)...\n" \
-            "retrying connection to WebOfScience because connection is throttled. Sleeping for 2 second(s)...\n" \
-            "retrying connection to WebOfScience because connection is throttled. Sleeping for 3 second(s)...\n"
-        ).to_stdout
-        expect(extractor).to have_received(:sleep).exactly(3).times
-      end
-    end
-    # rubocop:enable RSpec/VerifiedDoubles
-
-    context 'when there is more than one page of results' do
-      before do
-        stub_request(:get, 'https://api.clarivate.com/api/wos?count=2&databaseId=WOS&firstRecord=1&usrQuery=AU=Abel,Tom%20AND%20OG=Stanford%20University')
-          .to_return(status: 200, body: '{"Data":{"Records": { "records": {"REC": ["one", "two"]}}},'\
-            '"QueryResult": {"RecordsFound": 3}}')
-
-        stub_request(:get, 'https://api.clarivate.com/api/wos?count=2&databaseId=WOS&firstRecord=3&usrQuery=AU=Abel,Tom%20AND%20OG=Stanford%20University')
-          .to_return(status: 200, body: '{"Data":{"Records": { "records": {"REC": ["three"]}}},'\
-            '"QueryResult": {"RecordsFound": 3}}')
-
-        allow(extractor.send(:client)).to receive(:page_size).and_return(2)
-      end
-      it 'calls the block on each result' do
-        results = []
-        extractor.each do |records|
-          results << records
-        end
-        # rubocop:disable Lint/PercentStringArray
-        expect(results).to eq %w["one" "two" "three"]
-        # rubocop:enable Lint/PercentStringArray
-      end
-    end
-
-    context 'when there is only one result' do
-      before do
-        stub_request(:get, 'https://api.clarivate.com/api/wos?count=2&databaseId=WOS&firstRecord=1&usrQuery=AU=Abel,Tom%20AND%20OG=Stanford%20University')
-          .to_return(status: 200, body: '{"Data":{"Records": { "records": {"REC": "one"}}},'\
-            '"QueryResult": {"RecordsFound": 1}}')
-
-        allow(extractor.send(:client)).to receive(:page_size).and_return(2)
-      end
-      it 'calls the block on single result' do
-        results = []
-        extractor.each do |records|
-          results << records
-        end
-        expect(results).to eq ['"one"']
-      end
+    it 'iterates over client results and coerces to JSON' do
+      expect { |b| extractor.each(&b) }.to yield_successive_args('{"key1":"value1"}',
+                                                                 '{"key2":"value2"}')
     end
   end
 end


### PR DESCRIPTION
Refs sul-dlss/rialto#271

This branch commits a substantial redesign of the WoS extractor and the accompanying WoS API client. With the prior design, the extractor was failing to extract more than a few dozen records at a time due to the API balking at the number of connections to its user query API. Instead, the client should hit the user query API once per researcher and use the query ID that is returned by that request to issue subsequent queries about said researcher. In order to accommodate this change, I found it helpful to isolate knowledge of the API to the service client, making the extractor significantly dumber and the client significantly smarter. The client now acts like an enumerable, responding to `#each`, and preventing knowledge of the WoS API (e.g., dealing with throttled connections, knowing which endpoints to hit for what purposes) from leaking into the extractor.