### PR TITLE
Set the sample organization file for all tests

### DIFF
--- a/spec/configs/stanford_people_to_sparql_statements_spec.rb
+++ b/spec/configs/stanford_people_to_sparql_statements_spec.rb
@@ -223,9 +223,12 @@ RSpec.describe Rialto::Etl::Transformer do
       end
     end
 
+    before do
+      Rialto::Etl::Organizations.organizations_data = 'spec/translation_maps/organizations.json'
+    end
+
     describe 'insert' do
       before do
-        Rialto::Etl::Organizations.organizations_data = 'spec/translation_maps/organizations.json'
         transform(STANFORD_PERSON_INSERT)
       end
       it 'is inserted with person triples' do


### PR DESCRIPTION
Previously certain random test orders, we're causing tests that depended
on `Rialto::Etl::Organizations.organizations_data` were running before
it was set, causing them to fail.