### PR TITLE
Update  researcher load time

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Notes:
 1.6GB of data.
 * The transform step depends on `organizations.json` from organizations pipeline.
 * The transform step takes about 35 minutes on a single thread
-* The load step takes about 9 hours on a single thread
+* The load step takes about 7 hours on a single thread
 
 ```
 exe/extract call StanfordResearchers > researchers.ndj


### PR DESCRIPTION
Based on an actual run on rialto-vitro-dev.
```
INFO finished Indexer#process: 2834326 records in 25478.156 seconds; 111.2 records/second overall
```