### PR TITLE
Use method accessors consistently when referencing RDF classes and predicates

### DIFF
--- a/lib/rialto/etl/configs/stanford_grants_to_sparql_statements.rb
+++ b/lib/rialto/etl/configs/stanford_grants_to_sparql_statements.rb
@@ -54,11 +54,11 @@ to_field VIVO.relates.to_s, lambda { |json, accum|
   accum << {
     '@id' => pi_role,
     '@type' => VIVO.PrincipalInvestigatorRole,
-    "!{VIVO['relates'}" => true,
-    OBO['RO_0000052'].to_s => person,
+    "!#{VIVO.relates}" => true,
+    OBO.RO_0000052.to_s => person,
     '#person_to_role' => {
       '@id' => person,
-      OBO['RO_0000053'].to_s => pi_role
+      OBO.RO_0000053.to_s => pi_role
     },
     VIVO.relatedBy.to_s => RIALTO_GRANTS[json['spoNumber']]
   }

--- a/lib/rialto/etl/configs/stanford_people_to_sparql_statements.rb
+++ b/lib/rialto/etl/configs/stanford_people_to_sparql_statements.rb
@@ -105,13 +105,13 @@ to_field VIVO.relatedBy.to_s, lambda { |json, accum|
   accum.concat(advisees)
 }
 
-to_field OBO['RO_0000053'].to_s, lambda { |json, accum|
+to_field OBO.RO_0000053.to_s, lambda { |json, accum|
   unless JsonPath.on(json, '$.advisees').empty?
     accum << {
       '@id' => RIALTO_CONTEXT_ROLES['AdvisorRole'],
       '@type' => VIVO.AdvisorRole,
       # This points back at the advisor
-      OBO['RO_0000052'].to_s => RIALTO_PEOPLE[json['profileId']]
+      OBO.RO_0000052.to_s => RIALTO_PEOPLE[json['profileId']]
     }
   end
 }
@@ -126,11 +126,11 @@ to_field '#advisees', lambda { |json, accum|
     # Related by
     advisee_hash[VIVO.relatedBy.to_s] = RIALTO_CONTEXT_RELATIONSHIPS["#{advisee_json['profileId']}_#{json['profileId']}"]
     # Advisee role
-    advisee_hash[OBO['RO_0000053'].to_s] = {
+    advisee_hash[OBO.RO_0000053.to_s] = {
       '@id' => RIALTO_CONTEXT_ROLES['AdviseeRole'],
       '@type' => VIVO.AdviseeRole,
       # This points back at the advisee
-      OBO['RO_0000052'].to_s => RIALTO_PEOPLE[advisee_json['profileId']]
+      OBO.RO_0000052.to_s => RIALTO_PEOPLE[advisee_json['profileId']]
     }
     advisees << advisee_hash
   end

--- a/lib/rialto/etl/configs/wos_to_sparql_statements.rb
+++ b/lib/rialto/etl/configs/wos_to_sparql_statements.rb
@@ -142,7 +142,7 @@ to_field VIVO.relatedBy.to_s, lambda { |json, accumulator|
     {
       '@id' => RIALTO_CONTEXT_RELATIONSHIPS["#{json['UID']}_#{person_id}"],
       '@type' => c['role'] == 'book_editor' ? VIVO.Editorship : VIVO.Authorship,
-      "!{VIVO['relates'}" => true,
+      "!#{VIVO.relates}" => true,
       VIVO.relates.to_s => person['@id'],
       # Always add with # since always adding country for all people.
       '#person' => person

--- a/spec/configs/stanford_people_to_sparql_statements_spec.rb
+++ b/spec/configs/stanford_people_to_sparql_statements_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe Rialto::Etl::Transformer do
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150'],
-                                 RDF::Vocab::VCARD['hasName'],
+                                 RDF::Vocab::VCARD.hasName,
                                  Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['400150']])
                        .true?
         expect(result).to be true
@@ -335,7 +335,7 @@ RSpec.describe Rialto::Etl::Transformer do
         result = client.ask
                        .from(Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH)
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'],
-                                 RDF::Vocab::VCARD['hasName'],
+                                 RDF::Vocab::VCARD.hasName,
                                  Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['188882']])
         expect(result).to be_true
         result = client.ask
@@ -372,10 +372,10 @@ RSpec.describe Rialto::Etl::Transformer do
                                  RDF.type,
                                  Rialto::Etl::Vocabs::VIVO.AdvisorRole])
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150'],
-                                 Rialto::Etl::Vocabs::OBO['RO_0000053'],
+                                 Rialto::Etl::Vocabs::OBO.RO_0000053,
                                  Rialto::Etl::Vocabs::RIALTO_CONTEXT_ROLES['AdvisorRole']])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ROLES['AdvisorRole'],
-                                 Rialto::Etl::Vocabs::OBO['RO_0000052'],
+                                 Rialto::Etl::Vocabs::OBO.RO_0000052,
                                  Rialto::Etl::Vocabs::RIALTO_PEOPLE['400150']])
         expect(result).to be_true
 
@@ -386,10 +386,10 @@ RSpec.describe Rialto::Etl::Transformer do
                                  RDF.type,
                                  Rialto::Etl::Vocabs::VIVO.AdviseeRole])
                        .whether([Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'],
-                                 Rialto::Etl::Vocabs::OBO['RO_0000053'],
+                                 Rialto::Etl::Vocabs::OBO.RO_0000053,
                                  Rialto::Etl::Vocabs::RIALTO_CONTEXT_ROLES['AdviseeRole']])
                        .whether([Rialto::Etl::Vocabs::RIALTO_CONTEXT_ROLES['AdviseeRole'],
-                                 Rialto::Etl::Vocabs::OBO['RO_0000052'],
+                                 Rialto::Etl::Vocabs::OBO.RO_0000052,
                                  Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882']])
         expect(result).to be_true
 

--- a/spec/configs/wos_to_sparql_statements_spec.rb
+++ b/spec/configs/wos_to_sparql_statements_spec.rb
@@ -94,25 +94,25 @@ RSpec.describe Rialto::Etl::Transformer do
                                          graph])
         # has Part
         expect(repository).to have_quad([id,
-                                         RDF::Vocab::DC['isPartOf'],
+                                         RDF::Vocab::DC.isPartOf,
                                          'EXPERIMENTAL BIOLOGY AND MEDICINE',
                                          graph])
 
         # Created
         expect(repository).to have_quad([id,
-                                         RDF::Vocab::DC['created'],
+                                         RDF::Vocab::DC.created,
                                          RDF::Literal::Date.new('2018-02-01'),
                                          graph])
 
         # Subject
         expect(repository).to have_quad([id,
-                                         RDF::Vocab::DC['subject'],
+                                         RDF::Vocab::DC.subject,
                                          Rialto::Etl::Vocabs::RIALTO_CONCEPTS['d700824f-ae47-4244-885c-7cfc55b240f9'],
                                          graph])
 
         # Title
         expect(repository).to have_quad([id,
-                                         RDF::Vocab::DC['title'],
+                                         RDF::Vocab::DC.title,
                                          'Biomarkers: Delivering on the expectation of molecularly driven, quantitative health',
                                          graph])
 
@@ -265,17 +265,17 @@ RSpec.describe Rialto::Etl::Transformer do
 
       it 'is inserted with subject triples' do
         expect(repository).to have_quad([id,
-                                         RDF::Vocab::DC['subject'],
+                                         RDF::Vocab::DC.subject,
                                          Rialto::Etl::Vocabs::RIALTO_CONCEPTS['5a2cd5c7582ed1a1bbcc3a5c62786dca'],
                                          graph])
 
         expect(repository).to have_quad([Rialto::Etl::Vocabs::RIALTO_CONCEPTS['5a2cd5c7582ed1a1bbcc3a5c62786dca'],
                                          RDF.type,
-                                         RDF::Vocab::SKOS['Concept'],
+                                         RDF::Vocab::SKOS.Concept,
                                          graph])
 
         expect(repository).to have_quad([Rialto::Etl::Vocabs::RIALTO_CONCEPTS['5a2cd5c7582ed1a1bbcc3a5c62786dca'],
-                                         RDF::Vocab::DC['subject'],
+                                         RDF::Vocab::DC.subject,
                                          'Research & Experimental Medicine',
                                          graph])
       end
@@ -350,42 +350,42 @@ RSpec.describe Rialto::Etl::Transformer do
       it 'updates the publication' do
         # has Part
         expect(repository).to have_quad([id,
-                                         RDF::Vocab::DC['isPartOf'],
+                                         RDF::Vocab::DC.isPartOf,
                                          'SPECULATIVE BIOLOGY AND MEDICINE',
                                          graph])
         expect(repository).not_to have_quad([id,
-                                             RDF::Vocab::DC['isPartOf'],
+                                             RDF::Vocab::DC.isPartOf,
                                              'EXPERIMENTAL BIOLOGY AND MEDICINE',
                                              graph])
 
         # Created
         expect(repository).to have_quad([id,
-                                         RDF::Vocab::DC['created'],
+                                         RDF::Vocab::DC.created,
                                          RDF::Literal::Date.new('2017-02-01'),
                                          graph])
         expect(repository).not_to have_quad([id,
-                                             RDF::Vocab::DC['created'],
+                                             RDF::Vocab::DC.created,
                                              RDF::Literal::Date.new('2018-02-01'),
                                              graph])
 
         # Subject
         expect(repository).to have_quad([id,
-                                         RDF::Vocab::DC['subject'],
+                                         RDF::Vocab::DC.subject,
                                          Rialto::Etl::Vocabs::RIALTO_CONCEPTS['d700824f-ae47-4244-885c-7cfc55b240f10'],
                                          graph])
         expect(repository).not_to have_quad([id,
-                                             RDF::Vocab::DC['subject'],
+                                             RDF::Vocab::DC.subject,
                                              Rialto::Etl::Vocabs::RIALTO_CONCEPTS['d700824f-ae47-4244-885c-7cfc55b240f9'],
                                              graph])
 
         # Title
         expect(repository).to have_quad([id,
-                                         RDF::Vocab::DC['title'],
+                                         RDF::Vocab::DC.title,
                                          'Biomarkers: Delivering some day on the expectation of molecularly driven, '\
                                          'quantitative health',
                                          graph])
         expect(repository).not_to have_quad([id,
-                                             RDF::Vocab::DC['title'],
+                                             RDF::Vocab::DC.title,
                                              'Biomarkers: Delivering on the expectation of molecularly driven, quantitative health',
                                              graph])
 

--- a/spec/transformers/people_spec.rb
+++ b/spec/transformers/people_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Rialto::Etl::Transformers::People do
       it 'returns the correct fullname' do
         expect(vcard).to eq(
           '@id' => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['123'],
-          '@type' => RDF::Vocab::VCARD['Name'],
+          '@type' => RDF::Vocab::VCARD.Name,
           "!#{RDF::Vocab::VCARD['given-name']}" => true,
           "!#{RDF::Vocab::VCARD['additional-name']}" => true,
           "!#{RDF::Vocab::VCARD['family-name']}" => true,
@@ -185,7 +185,7 @@ RSpec.describe Rialto::Etl::Transformers::People do
         it 'returns the correct fullname' do
           expect(vcard).to eq(
             '@id' => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['ed1aa059391f675499eda6172ddc29f4'],
-            '@type' => RDF::Vocab::VCARD['Name'],
+            '@type' => RDF::Vocab::VCARD.Name,
             "!#{RDF::Vocab::VCARD['given-name']}" => true,
             "!#{RDF::Vocab::VCARD['additional-name']}" => true,
             "!#{RDF::Vocab::VCARD['family-name']}" => true,
@@ -247,9 +247,9 @@ RSpec.describe Rialto::Etl::Transformers::People do
                                            'Justin Cunningham Littman', 'Littman, Justin C', 'Littman, Justin C.',
                                            'Justin C Littman', 'Justin C. Littman', 'Littman, JC', 'Littman, J.C.',
                                            'JC Littman', 'J.C. Littman'],
-        RDF::Vocab::VCARD['hasName'].to_s => {
+        RDF::Vocab::VCARD.hasName.to_s => {
           '@id' => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['123'],
-          '@type' => RDF::Vocab::VCARD['Name'],
+          '@type' => RDF::Vocab::VCARD.Name,
           "!#{RDF::Vocab::VCARD['given-name']}" => true,
           "!#{RDF::Vocab::VCARD['additional-name']}" => true,
           "!#{RDF::Vocab::VCARD['family-name']}" => true,

--- a/spec/writers/sparql_statement_writer_spec.rb
+++ b/spec/writers/sparql_statement_writer_spec.rb
@@ -73,12 +73,12 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
         '@graph' => Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH.to_s,
         '@type' => [RDF::Vocab::FOAF.Person, Rialto::Etl::Vocabs::Stanford.Staff],
         Rialto::Etl::Vocabs::VIVO.overview.to_s => 'Justin Littman is a software developer and librarian.',
-        RDF::Vocab::VCARD['hasEmail'].to_s => 'jlittypo@example.org',
+        RDF::Vocab::VCARD.hasEmail.to_s => 'jlittypo@example.org',
         '#advisee' => {
           '@id' => Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'].to_s,
           '@graph' => Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH.to_s,
           '@type' => [RDF::Vocab::FOAF.Person],
-          RDF::Vocab::VCARD['hasName'].to_s => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['188882']
+          RDF::Vocab::VCARD.hasName.to_s => Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['188882']
         }
       }
     end
@@ -88,8 +88,8 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
         '@id' => Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'].to_s,
         '@graph' => Rialto::Etl::NamedGraphs::STANFORD_PEOPLE_GRAPH.to_s,
         '@type' => [RDF::Vocab::FOAF.Person, Rialto::Etl::Vocabs::Stanford.Staff],
-        "!#{RDF::Vocab::VCARD['hasEmail']}" => true,
-        RDF::Vocab::VCARD['hasEmail'].to_s => 'jlit@example.org'
+        "!#{RDF::Vocab::VCARD.hasEmail}" => true,
+        RDF::Vocab::VCARD.hasEmail.to_s => 'jlit@example.org'
       }
     end
 
@@ -104,11 +104,11 @@ RSpec.describe Rialto::Etl::Writers::SparqlStatementWriter do
                 Rialto::Etl::Vocabs::VIVO.overview,
                 'Justin Littman is a software developer and librarian.']
       graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['1234'],
-                RDF::Vocab::VCARD['hasEmail'],
+                RDF::Vocab::VCARD.hasEmail,
                 'jlit@example.org']
       graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'], RDF.type, RDF::Vocab::FOAF.Person]
       graph << [Rialto::Etl::Vocabs::RIALTO_PEOPLE['188882'],
-                RDF::Vocab::VCARD['hasName'],
+                RDF::Vocab::VCARD.hasName,
                 Rialto::Etl::Vocabs::RIALTO_CONTEXT_NAMES['188882']]
 
       execute_sparql!(first_statements)


### PR DESCRIPTION
With one exception: predicates containing hyphens, which the VCARD ontology uses. Hyphens can not be used in method names in Ruby; they are syntax errors. Continue to use hash accessors for this instead of resorting to `#public_send`.